### PR TITLE
Add private board membership total to embed

### DIFF
--- a/bot/resources/advent_of_code/about.json
+++ b/bot/resources/advent_of_code/about.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "What is Advent of Code?",
-        "value": "Advent of Code (AoC) is an series of small programming puzzles for a variety of skill levels, run every year during the month of December.\n\nThey are self-contained and are just as appropriate for an expert who wants to stay sharp as they are for a beginner who is just learning to code. Each puzzle calls upon different skills and has two parts that build on a theme.",
+        "value": "Advent of Code (AoC) is a series of small programming puzzles for a variety of skill levels, run every year during the month of December.\n\nThey are self-contained and are just as appropriate for an expert who wants to stay sharp as they are for a beginner who is just learning to code. Each puzzle calls upon different skills and has two parts that build on a theme.",
         "inline": false
     },
     {

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -212,7 +212,7 @@ class AdventOfCode:
                 description=f"Total members: {len(self.cached_private_leaderboard.members)}",
                 colour=Colours.soft_green,
                 timestamp=self.cached_private_leaderboard.last_updated
-                )
+            )
             aoc_embed.set_author(name="Advent of Code", url=self.private_leaderboard_url)
             aoc_embed.set_footer(text="Last Updated")
 

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -208,7 +208,11 @@ class AdventOfCode:
             table = AocPrivateLeaderboard.build_leaderboard_embed(members_to_print)
 
             # Build embed
-            aoc_embed = discord.Embed(colour=Colours.soft_green, timestamp=self.cached_private_leaderboard.last_updated)
+            aoc_embed = discord.Embed(
+                description=f"Total members: {len(self.cached_private_leaderboard.members)}",
+                colour=Colours.soft_green,
+                timestamp=self.cached_private_leaderboard.last_updated
+                )
             aoc_embed.set_author(name="Advent of Code", url=self.private_leaderboard_url)
             aoc_embed.set_footer(text="Last Updated")
 


### PR DESCRIPTION
Minor tweak to the private leaderboard embed to display the membership count for the board

![image](https://user-images.githubusercontent.com/5323929/49343349-2b99cf00-f635-11e8-99ee-bb72bda1c273.png)
