### PR TITLE
Send devlog notification on season load.

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -4,7 +4,10 @@ from traceback import format_exc
 from typing import List
 
 from aiohttp import AsyncResolver, ClientSession, TCPConnector
+from discord import Embed
 from discord.ext.commands import Bot
+
+from bot import constants
 
 log = logging.getLogger(__name__)
 
@@ -40,3 +43,21 @@ class SeasonalBot(Bot):
                 log.info(f'Successfully loaded extension: {cog}')
             except Exception as e:
                 log.error(f'Failed to load extension {cog}: {repr(e)} {format_exc()}')
+
+    async def send_log(self, title: str, details: str = None, *, icon: str = None):
+        """
+        Send an embed message to the devlog channel
+        """
+        devlog = self.get_channel(constants.Channels.devlog)
+
+        if not devlog:
+            log.warning("Log failed to send. Devlog channel not found.")
+            return
+
+        if not icon:
+            icon = self.user.avatar_url_as(format="png")
+
+        embed = Embed(description=details)
+        embed.set_author(name=title, icon_url=icon)
+
+        await devlog.send(embed=embed)

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -29,7 +29,7 @@ class Channels(NamedTuple):
     bot = 267659945086812160
     checkpoint_test = 422077681434099723
     devalerts = 460181980097675264
-    devlog = 409308876241108992
+    devlog = int(environ.get('CHANNEL_DEVLOG', 409308876241108992))
     devtest = 414574275865870337
     help_0 = 303906576991780866
     help_1 = 303906556754395136

--- a/bot/seasons/season.py
+++ b/bot/seasons/season.py
@@ -330,7 +330,7 @@ class SeasonBase:
         # Apply seasonal elements after extensions successfully load
         username_changed = await self.apply_username(debug=Client.debug)
 
-        # Avoid major changes and annoucements if debug mode
+        # Avoid major changes and announcements if debug mode
         if not Client.debug:
             log.info("Applying avatar.")
             await self.apply_avatar()


### PR DESCRIPTION
Resolves #83 

A notification is sent to devlog on the new loading of a season. This means it will effectively send a notification on:
- Season changes to a special season
- Season changes to evergreen
- Bot starts/restarts and loads the current season

These notifications will be sent regardless of debug mode setting.

Notification posted to devlog looks like:
![image](https://user-images.githubusercontent.com/29337040/49481041-d3e9a680-f874-11e8-9d33-ae61d0509d2b.png)

Additionally resolves a bug with the `load_seasons` method where on checking for different seasons at midnight, it would always think it's a new one, resulting in the devlog notification being re-sent every midnight.