### PR TITLE
AoC Join Code Refactor

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 class AdventOfCode:
     leaderboard_cache_age_threshold_seconds = 3600
     leaderboard_id = 363275
-    leaderboard_join_code = "363275-442b6939"
+    leaderboard_join_code = str(environ.get("AOC_JOIN_CODE", None))
     leaderboard_max_displayed_members = 10
     year = 2018
     channel_id = int(environ.get("AOC_CHANNEL_ID", 517745814039166986))

--- a/bot/resources/advent_of_code/about.json
+++ b/bot/resources/advent_of_code/about.json
@@ -21,7 +21,7 @@
     },
     {
         "name": "Join our private leaderboard!",
-        "value": "In addition to the global leaderboard, AoC also offers private leaderboards, where you can compete against a smaller group of friends!\n\nHead over to AoC's [private leaderboard page](https://adventofcode.com/leaderboard/private) and enter code `363275-442b6939` to join the PyDis private leaderboard!",
+        "value": "In addition to the global leaderboard, AoC also offers private leaderboards, where you can compete against a smaller group of friends!\n\nGet the join code using `.aoc join` and head over to AoC's [private leaderboard page](https://adventofcode.com/leaderboard/private) to join the PyDis private leaderboard!",
         "inline": false
     }
 ]

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -210,9 +210,7 @@ class AdventOfCode:
             await author.send(info_str)
         except discord.errors.Forbidden:
             log.debug(f"{author.name} ({author.id}) has disabled DMs from server members")
-            await ctx.send(
-                f':x: {author.mention}, please (temporarily) enable DMs to receive the join code'
-            )
+            await ctx.send(f":x: {author.mention}, please (temporarily) enable DMs to receive the join code")
 
     @adventofcode_group.command(
         name="leaderboard",

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -223,7 +223,7 @@ class AdventOfCode:
         Staff command to update the AoC join code constant locally to allow for the code to be updated
         on regeneration without having to redeploy the bot
         """
-        
+
         author = ctx.message.author
         log.info(f"{author.name} ({author.id}) has changed the PyDis AoC leaderboard code")
 

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 
 AOC_REQUEST_HEADER = {"user-agent": "PythonDiscord AoC Event Bot"}
 AOC_SESSION_COOKIE = {"session": Tokens.aoc_session_cookie}
+AOC_JOIN_CODE = AocConfig.leaderboard_join_code  # Constant so staff can update without redeploying
 
 EST = timezone("EST")
 COUNTDOWN_STEP = 60 * 5
@@ -196,14 +197,23 @@ class AdventOfCode:
     @adventofcode_group.command(name="join", aliases=("j",), brief="Learn how to join PyDis' private AoC leaderboard")
     async def join_leaderboard(self, ctx: commands.Context):
         """
-        Retrieve the link to join the PyDis AoC private leaderboard
+        DM the user the information for joining the PyDis AoC private leaderboard
         """
+
+        author = ctx.message.author
+        log.info(f"{author.name} ({author.id}) has requested the PyDis AoC leaderboard code")
 
         info_str = (
             "Head over to https://adventofcode.com/leaderboard/private "
-            f"with code `{AocConfig.leaderboard_join_code}` to join the PyDis private leaderboard!"
+            f"with code `{AOC_JOIN_CODE}` to join the PyDis private leaderboard!"
         )
-        await ctx.send(info_str)
+        try:
+            await author.send(info_str)
+        except discord.errors.Forbidden:
+            log.debug(f"{author.name} ({author.id}) has disabled DMs from server members")
+            await ctx.send(
+                f':x: {author.mention}, please (temporarily) enable DMs to receive the join code'
+            )
 
     @adventofcode_group.command(
         name="leaderboard",

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -13,8 +13,7 @@ from bs4 import BeautifulSoup
 from discord.ext import commands
 from pytz import timezone
 
-from bot.constants import AdventOfCode as AocConfig, Colours, Emojis, Roles, Tokens
-from bot.decorators import with_role
+from bot.constants import AdventOfCode as AocConfig, Colours, Emojis, Tokens
 
 log = logging.getLogger(__name__)
 

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -20,7 +20,6 @@ log = logging.getLogger(__name__)
 
 AOC_REQUEST_HEADER = {"user-agent": "PythonDiscord AoC Event Bot"}
 AOC_SESSION_COOKIE = {"session": Tokens.aoc_session_cookie}
-AOC_JOIN_CODE = AocConfig.leaderboard_join_code  # Constant so staff can update without redeploying
 
 EST = timezone("EST")
 COUNTDOWN_STEP = 60 * 5
@@ -206,7 +205,7 @@ class AdventOfCode:
 
         info_str = (
             "Head over to https://adventofcode.com/leaderboard/private "
-            f"with code `{AOC_JOIN_CODE}` to join the PyDis private leaderboard!"
+            f"with code `{AocConfig.leaderboard_join_code}` to join the PyDis private leaderboard!"
         )
         try:
             await author.send(info_str)
@@ -215,20 +214,6 @@ class AdventOfCode:
             await ctx.send(
                 f':x: {author.mention}, please (temporarily) enable DMs to receive the join code'
             )
-
-    @with_role(Roles.admin, Roles.owner)
-    @adventofcode_group.command(name="changecode", hidden=True)
-    async def update_aoc_join_code(self, ctx: commands.Context, new_code: str):
-        """
-        Staff command to update the AoC join code constant locally to allow for the code to be updated
-        on regeneration without having to redeploy the bot
-        """
-
-        author = ctx.message.author
-        log.info(f"{author.name} ({author.id}) has changed the PyDis AoC leaderboard code")
-
-        global AOC_JOIN_CODE  # Necessary (probably?) evil to update the code without redeploying
-        AOC_JOIN_CODE = new_code
 
     @adventofcode_group.command(
         name="leaderboard",

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -13,7 +13,8 @@ from bs4 import BeautifulSoup
 from discord.ext import commands
 from pytz import timezone
 
-from bot.constants import AdventOfCode as AocConfig, Colours, Emojis, Tokens
+from bot.constants import AdventOfCode as AocConfig, Colours, Emojis, Roles, Tokens
+from bot.decorators import with_role
 
 log = logging.getLogger(__name__)
 
@@ -214,6 +215,20 @@ class AdventOfCode:
             await ctx.send(
                 f':x: {author.mention}, please (temporarily) enable DMs to receive the join code'
             )
+
+    @with_role(Roles.admin, Roles.owner)
+    @adventofcode_group.command(name="changecode", hidden=True)
+    async def update_aoc_join_code(self, ctx: commands.Context, new_code: str):
+        """
+        Staff command to update the AoC join code constant locally to allow for the code to be updated
+        on regeneration without having to redeploy the bot
+        """
+        
+        author = ctx.message.author
+        log.info(f"{author.name} ({author.id}) has changed the PyDis AoC leaderboard code")
+
+        global AOC_JOIN_CODE  # Necessary (probably?) evil to update the code without redeploying
+        AOC_JOIN_CODE = new_code
 
     @adventofcode_group.command(
         name="leaderboard",


### PR DESCRIPTION
Refactor `.aoc join` to DM the user with the code.

Also updates the `.aoc about` to direct the user to get the current leaderboard code from the `.aoc join` command.