### PR TITLE
Fix advent of code countdown

### DIFF
--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -180,6 +180,10 @@ class AdventOfCode:
         """
         Return time left until next day
         """
+        if not is_in_advent():
+            await ctx.send(f"Advent of Code is no longer running this year! Come back next year for more puzzles!")
+            return
+
         tomorrow, time_left = time_left_to_aoc_midnight()
 
         hours, minutes = time_left.seconds // 3600, time_left.seconds // 60 % 60

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -29,7 +29,8 @@ def is_in_advent() -> bool:
     Utility function to check if we are between December 1st
     and December 25th.
     """
-    return datetime.now(EST).day in range(1, 26) and datetime.now(EST).month == 12
+    # Run the code from the 1st to the 24th
+    return datetime.now(EST).day in range(1, 25) and datetime.now(EST).month == 12
 
 
 def time_left_to_aoc_midnight() -> Tuple[datetime, timedelta]:


### PR DESCRIPTION
So currently the countdown code is not only running until the 25th but also on the 25th which means it is counting down to a day 26.

This pull request makes the following changes:
- Only run advent of code countdown timers from December 1st to December 25th.
- Don't let the countdown command run when it is not December 1st to December 25th.