### PR TITLE
Add valentines season

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -63,6 +63,7 @@ class Colours:
     soft_green = 0x68c290
     dark_green = 0x1f8b4c
     orange = 0xe67e22
+    pink = 0xcf84e0
 
 
 class Emojis:

--- a/bot/seasons/valentines/__init__.py
+++ b/bot/seasons/valentines/__init__.py
@@ -1,0 +1,19 @@
+from bot.constants import Colours
+from bot.seasons import SeasonBase
+
+
+class Valentines(SeasonBase):
+    """
+    Love is in the air! We've got a new icon and set of commands for the season of love.
+
+    Get yourself into the bot-commands channel and check out the new features!
+    """
+    name = "valentines"
+    bot_name = "Tenderbot"
+    greeting = "Get loved-up!"
+
+    start_date = "01/02"
+    end_date = "01/03"
+
+    colour = Colours.pink
+    icon = "/logos/logo_seasonal/valentines/loved_up.png"


### PR DESCRIPTION
Implements a new valentines day season for the SeasonalBot.

~~Blocks on a PR being opened for python-discord/branding#1 to add an icon under `/logos/logo_seasonal/valentines/loved_up.png`.~~ python-discord/branding#4 has been merged