### PR TITLE
Fix LoveCalculator 0% bug

### DIFF
--- a/bot/resources/valentines/love_matches.json
+++ b/bot/resources/valentines/love_matches.json
@@ -1,5 +1,5 @@
 {
-    "0": {
+    "100": {
         "titles": [
             "\ud83d\udc9b When will you two marry? \ud83d\udc9b",
             "\ud83d\udc9b Now kiss already \ud83d\udc9b"
@@ -49,7 +49,7 @@
         ],
         "text": "There might be a chance of this relationship working out somewhat well, but it is not very high. With a lot of time and effort you'll get it to work eventually, however don't count on it. It might fall apart quicker than you'd expect."
     },
-    "1": {
+    "0": {
         "titles": [
             "\ud83d\udc94 There's no real connection between you two \ud83d\udc94"
         ],

--- a/bot/seasons/valentines/lovecalculator.py
+++ b/bot/seasons/valentines/lovecalculator.py
@@ -47,7 +47,7 @@ class LoveCalculator:
             staff = ctx.guild.get_role(Roles.helpers).members
             name_two = choice(staff)
 
-        love_meter = (name_one.id + name_two.id) % 100
+        love_meter = (name_one.id + name_two.id) % 101
         love_idx = str(sorted(x for x in LOVE_LEVELS if x <= love_meter)[-1])
         love_status = choice(LOVE_DATA[love_idx]["titles"])
 


### PR DESCRIPTION
Recently a test of the .love command revealed an unintentional reaction
when 100% are reached. In previous versions this command had used a
gigantic conditional block, checking for the current percentage given by
the love_meter formula. When reaching 0 (meaning that the UserID's
evenly divided with 100) it would automatically convert that 0 to 100. A
big mistake from my side back then.

This has been fixed with these changes. By quickly modifying the formula
to use a mod 101 instead of a mod 100, we get an accurate percentage,
ranging from 0-100% instead of 0-99%. love_matches.json has also been
fixed to address these changes, meaning that the lowest entry now
actually is 0 and the highest 100.

TL;DR:
-> Edited love_meter formula to calculate mod 101 instead of mod 100
-> Edited lowest and highest entry in love_matches.json to be 0 and 100