### PR TITLE
Cog inheritance hotfix

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-discord-py = {ref = "42a7c4f",git = "https://github.com/Rapptz/discord.py",editable = true}
+discord-py = {ref = "43b4475",git = "https://github.com/Rapptz/discord.py",editable = true}
 arrow = "*"
 beautifulsoup4 = "*"
 aiodns = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d8e3a7f796632bf80bc0c0b8ed2162d3f39aa91e8afa424d3ae85f2210a71923"
+            "sha256": "c31b92d7603d1173bd68337ade1630d26526a1b99fb229cd0d89f3493261f575"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -125,7 +125,7 @@
         "discord-py": {
             "editable": true,
             "git": "https://github.com/Rapptz/discord.py",
-            "ref": "42a7c4f7e5caa7baf555e86b52249419ce33acfc"
+            "ref": "43b44751af647ecfcfb17868962972d543eb69a9"
         },
         "fuzzywuzzy": {
             "hashes": [
@@ -260,36 +260,36 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:afa56bf14907bb09403e5d15fbed6275caa4174d36b975226e3b67a3bb6e2c4b",
-                "sha256:eaed742b48b1f3e2d45ba6f79401b2ed5dc33b2123dfe216adb90d4bfa0ade26"
+                "sha256:3aef141566afd07201b525c17bfaadd07580a8066f82b57f7c9417f26adbd0a3",
+                "sha256:e41a65e99bd125972d84221022beb1e4b5cfc68fa12c170c39834ce32d1b294c"
             ],
-            "version": "==1.8"
+            "version": "==1.9"
         },
         "websockets": {
             "hashes": [
-                "sha256:04b42a1b57096ffa5627d6a78ea1ff7fad3bc2c0331ffc17bc32a4024da7fea0",
-                "sha256:08e3c3e0535befa4f0c4443824496c03ecc25062debbcf895874f8a0b4c97c9f",
-                "sha256:10d89d4326045bf5e15e83e9867c85d686b612822e4d8f149cf4840aab5f46e0",
-                "sha256:232fac8a1978fc1dead4b1c2fa27c7756750fb393eb4ac52f6bc87ba7242b2fa",
-                "sha256:4bf4c8097440eff22bc78ec76fe2a865a6e658b6977a504679aaf08f02c121da",
-                "sha256:51642ea3a00772d1e48fb0c492f0d3ae3b6474f34d20eca005a83f8c9c06c561",
-                "sha256:55d86102282a636e195dad68aaaf85b81d0bef449d7e2ef2ff79ac450bb25d53",
-                "sha256:564d2675682bd497b59907d2205031acbf7d3fadf8c763b689b9ede20300b215",
-                "sha256:5d13bf5197a92149dc0badcc2b699267ff65a867029f465accfca8abab95f412",
-                "sha256:5eda665f6789edb9b57b57a159b9c55482cbe5b046d7db458948370554b16439",
-                "sha256:5edb2524d4032be4564c65dc4f9d01e79fe8fad5f966e5b552f4e5164fef0885",
-                "sha256:79691794288bc51e2a3b8de2bc0272ca8355d0b8503077ea57c0716e840ebaef",
-                "sha256:7fcc8681e9981b9b511cdee7c580d5b005f3bb86b65bde2188e04a29f1d63317",
-                "sha256:8e447e05ec88b1b408a4c9cde85aa6f4b04f06aa874b9f0b8e8319faf51b1fee",
-                "sha256:90ea6b3e7787620bb295a4ae050d2811c807d65b1486749414f78cfd6fb61489",
-                "sha256:9e13239952694b8b831088431d15f771beace10edfcf9ef230cefea14f18508f",
-                "sha256:d40f081187f7b54d7a99d8a5c782eaa4edc335a057aa54c85059272ed826dc09",
-                "sha256:e1df1a58ed2468c7b7ce9a2f9752a32ad08eac2bcd56318625c3647c2cd2da6f",
-                "sha256:e98d0cec437097f09c7834a11c69d79fe6241729b23f656cfc227e93294fc242",
-                "sha256:f8d59627702d2ff27cb495ca1abdea8bd8d581de425c56e93bff6517134e0a9b",
-                "sha256:fc30cdf2e949a2225b012a7911d1d031df3d23e99b7eda7dfc982dc4a860dae9"
+                "sha256:0e2f7d6567838369af074f0ef4d0b802d19fa1fee135d864acc656ceefa33136",
+                "sha256:2a16dac282b2fdae75178d0ed3d5b9bc3258dabfae50196cbb30578d84b6f6a6",
+                "sha256:5a1fa6072405648cb5b3688e9ed3b94be683ce4a4e5723e6f5d34859dee495c1",
+                "sha256:5c1f55a1274df9d6a37553fef8cff2958515438c58920897675c9bc70f5a0538",
+                "sha256:669d1e46f165e0ad152ed8197f7edead22854a6c90419f544e0f234cc9dac6c4",
+                "sha256:695e34c4dbea18d09ab2c258994a8bf6a09564e762655408241f6a14592d2908",
+                "sha256:6b2e03d69afa8d20253455e67b64de1a82ff8612db105113cccec35d3f8429f0",
+                "sha256:79ca7cdda7ad4e3663ea3c43bfa8637fc5d5604c7737f19a8964781abbd1148d",
+                "sha256:7fd2dd9a856f72e6ed06f82facfce01d119b88457cd4b47b7ae501e8e11eba9c",
+                "sha256:82c0354ac39379d836719a77ee360ef865377aa6fdead87909d50248d0f05f4d",
+                "sha256:8f3b956d11c5b301206382726210dc1d3bee1a9ccf7aadf895aaf31f71c3716c",
+                "sha256:91ec98640220ae05b34b79ee88abf27f97ef7c61cf525eec57ea8fcea9f7dddb",
+                "sha256:952be9540d83dba815569d5cb5f31708801e0bbfc3a8c5aef1890b57ed7e58bf",
+                "sha256:99ac266af38ba1b1fe13975aea01ac0e14bb5f3a3200d2c69f05385768b8568e",
+                "sha256:9fa122e7adb24232247f8a89f2d9070bf64b7869daf93ac5e19546b409e47e96",
+                "sha256:a0873eadc4b8ca93e2e848d490809e0123eea154aa44ecd0109c4d0171869584",
+                "sha256:cb998bd4d93af46b8b49ecf5a72c0a98e5cc6d57fdca6527ba78ad89d6606484",
+                "sha256:e02e57346f6a68523e3c43bbdf35dde5c440318d1f827208ae455f6a2ace446d",
+                "sha256:e79a5a896bcee7fff24a788d72e5c69f13e61369d055f28113e71945a7eb1559",
+                "sha256:ee55eb6bcf23ecc975e6b47c127c201b913598f38b6a300075f84eeef2d3baff",
+                "sha256:f1414e6cbcea8d22843e7eafdfdfae3dd1aba41d1945f6ca66e4806c07c4f454"
             ],
-            "version": "==7.0"
+            "version": "==6.0"
         },
         "yarl": {
             "hashes": [
@@ -435,19 +435,19 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
-                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
-                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
-                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
-                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
-                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
-                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
-                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
-                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
-                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
-                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
+                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
+                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
+                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
+                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
+                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
+                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
+                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
+                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
+                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
+                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
             ],
-            "version": "==3.13"
+            "version": "==5.1"
         },
         "six": {
             "hashes": [

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -103,7 +103,7 @@ async def day_countdown(bot: commands.Bot):
         await asyncio.sleep(120)
 
 
-class AdventOfCode:
+class AdventOfCode(commands.Cog):
     """Advent of Code festivities! Ho Ho Ho."""
 
     def __init__(self, bot: commands.Bot):

--- a/bot/seasons/easter/__init__.py
+++ b/bot/seasons/easter/__init__.py
@@ -26,7 +26,7 @@ class Easter(SeasonBase):
     greeting = "Happy Easter!"
 
     # Duration of season
-    start_date = "01/04"
+    start_date = "02/04"
     end_date = "30/04"
 
     colour = Colours.pink

--- a/bot/seasons/evergreen/error_handler.py
+++ b/bot/seasons/evergreen/error_handler.py
@@ -8,7 +8,7 @@ from discord.ext import commands
 log = logging.getLogger(__name__)
 
 
-class CommandErrorHandler:
+class CommandErrorHandler(commands.Cog):
     """A error handler for the PythonDiscord server."""
 
     def __init__(self, bot):

--- a/bot/seasons/evergreen/fun.py
+++ b/bot/seasons/evergreen/fun.py
@@ -8,7 +8,7 @@ from bot.constants import Emojis
 log = logging.getLogger(__name__)
 
 
-class Fun:
+class Fun(commands.Cog):
     """A collection of general commands for fun."""
 
     def __init__(self, bot):

--- a/bot/seasons/evergreen/magic_8ball.py
+++ b/bot/seasons/evergreen/magic_8ball.py
@@ -8,7 +8,7 @@ from discord.ext import commands
 log = logging.getLogger(__name__)
 
 
-class Magic8ball:
+class Magic8ball(commands.Cog):
     """
     A Magic 8ball command to respond to a users question.
     """

--- a/bot/seasons/evergreen/uptime.py
+++ b/bot/seasons/evergreen/uptime.py
@@ -9,7 +9,7 @@ from bot import start_time
 log = logging.getLogger(__name__)
 
 
-class Uptime:
+class Uptime(commands.Cog):
     """A cog for posting the bot's uptime."""
 
     def __init__(self, bot):

--- a/bot/seasons/halloween/candy_collection.py
+++ b/bot/seasons/halloween/candy_collection.py
@@ -20,7 +20,7 @@ ADD_SKULL_REACTION_CHANCE = 50  # 2%
 ADD_SKULL_EXISTING_REACTION_CHANCE = 20  # 5%
 
 
-class CandyCollection:
+class CandyCollection(commands.Cog):
     """Candy collection game Cog."""
 
     def __init__(self, bot):

--- a/bot/seasons/halloween/hacktoberstats.py
+++ b/bot/seasons/halloween/hacktoberstats.py
@@ -13,7 +13,7 @@ from discord.ext import commands
 log = logging.getLogger(__name__)
 
 
-class HacktoberStats:
+class HacktoberStats(commands.Cog):
     """Hacktoberfest statistics Cog."""
 
     def __init__(self, bot):

--- a/bot/seasons/halloween/halloween_facts.py
+++ b/bot/seasons/halloween/halloween_facts.py
@@ -25,7 +25,7 @@ PUMPKIN_ORANGE = discord.Color(0xFF7518)
 INTERVAL = timedelta(hours=6).total_seconds()
 
 
-class HalloweenFacts:
+class HalloweenFacts(commands.Cog):
     """A Cog for displaying interesting facts about Halloween."""
 
     def __init__(self, bot):

--- a/bot/seasons/halloween/halloweenify.py
+++ b/bot/seasons/halloween/halloweenify.py
@@ -10,7 +10,7 @@ from discord.ext.commands.cooldowns import BucketType
 log = logging.getLogger(__name__)
 
 
-class Halloweenify:
+class Halloweenify(commands.Cog):
     """A cog to change a invokers nickname to a spooky one!"""
 
     def __init__(self, bot):

--- a/bot/seasons/halloween/scarymovie.py
+++ b/bot/seasons/halloween/scarymovie.py
@@ -13,7 +13,7 @@ TMDB_API_KEY = environ.get('TMDB_API_KEY')
 TMDB_TOKEN = environ.get('TMDB_TOKEN')
 
 
-class ScaryMovie:
+class ScaryMovie(commands.Cog):
     """Selects a random scary movie and embeds info into Discord chat."""
 
     def __init__(self, bot):

--- a/bot/seasons/halloween/spookyavatar.py
+++ b/bot/seasons/halloween/spookyavatar.py
@@ -12,7 +12,7 @@ from bot.utils.halloween import spookifications
 log = logging.getLogger(__name__)
 
 
-class SpookyAvatar:
+class SpookyAvatar(commands.Cog):
     """A cog that spookifies an avatar."""
 
     def __init__(self, bot):

--- a/bot/seasons/halloween/spookygif.py
+++ b/bot/seasons/halloween/spookygif.py
@@ -9,7 +9,7 @@ from bot.constants import Tokens
 log = logging.getLogger(__name__)
 
 
-class SpookyGif:
+class SpookyGif(commands.Cog):
     """A cog to fetch a random spooky gif from the web!"""
 
     def __init__(self, bot):

--- a/bot/seasons/halloween/spookyreact.py
+++ b/bot/seasons/halloween/spookyreact.py
@@ -17,7 +17,7 @@ SPOOKY_TRIGGERS = {
 }
 
 
-class SpookyReact:
+class SpookyReact(Cog):
     """A cog that makes the bot react to message triggers."""
 
     def __init__(self, bot):

--- a/bot/seasons/halloween/spookysound.py
+++ b/bot/seasons/halloween/spookysound.py
@@ -10,7 +10,7 @@ from bot.constants import Hacktoberfest
 log = logging.getLogger(__name__)
 
 
-class SpookySound:
+class SpookySound(commands.Cog):
     """A cog that plays a spooky sound in a voice channel on command."""
 
     def __init__(self, bot):

--- a/bot/seasons/halloween/timeleft.py
+++ b/bot/seasons/halloween/timeleft.py
@@ -6,7 +6,7 @@ from discord.ext import commands
 log = logging.getLogger(__name__)
 
 
-class TimeLeft:
+class TimeLeft(commands.Cog):
     """A Cog that tells you how long left until Hacktober is over!"""
 
     def __init__(self, bot):

--- a/bot/seasons/season.py
+++ b/bot/seasons/season.py
@@ -538,5 +538,5 @@ class SeasonManager(commands.Cog):
 
         await self.season.announce_season()
 
-    def __unload(self):
+    def cog_unload(self):
         self.season_task.cancel()

--- a/bot/seasons/season.py
+++ b/bot/seasons/season.py
@@ -349,7 +349,7 @@ class SeasonBase:
         await bot.send_log("SeasonalBot Loaded!", f"Active Season: **{self.name_clean}**")
 
 
-class SeasonManager:
+class SeasonManager(commands.Cog):
     """A cog for managing seasons."""
 
     def __init__(self, bot):

--- a/bot/seasons/season.py
+++ b/bot/seasons/season.py
@@ -539,4 +539,6 @@ class SeasonManager(commands.Cog):
         await self.season.announce_season()
 
     def cog_unload(self):
+        """Cancel season-related tasks on cog unload."""
+
         self.season_task.cancel()

--- a/bot/seasons/valentines/be_my_valentine.py
+++ b/bot/seasons/valentines/be_my_valentine.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 HEART_EMOJIS = [":heart:", ":gift_heart:", ":revolving_hearts:", ":sparkling_heart:", ":two_hearts:"]
 
 
-class BeMyValentine:
+class BeMyValentine(commands.Cog):
     """A cog that sends Valentines to other users!"""
 
     def __init__(self, bot):

--- a/bot/seasons/valentines/movie_generator.py
+++ b/bot/seasons/valentines/movie_generator.py
@@ -11,7 +11,7 @@ TMDB_API_KEY = environ.get("TMDB_API_KEY")
 log = logging.getLogger(__name__)
 
 
-class RomanceMovieFinder:
+class RomanceMovieFinder(commands.Cog):
     """A cog that returns a random romance movie suggestion to a user."""
 
     def __init__(self, bot):

--- a/bot/seasons/valentines/myvalenstate.py
+++ b/bot/seasons/valentines/myvalenstate.py
@@ -15,7 +15,7 @@ with open(Path('bot', 'resources', 'valentines', 'valenstates.json'), 'r') as fi
     STATES = json.load(file)
 
 
-class MyValenstate:
+class MyValenstate(commands.Cog):
     """A Cog to find your most likely Valentine's vacation destination."""
 
     def __init__(self, bot):

--- a/bot/seasons/valentines/pickuplines.py
+++ b/bot/seasons/valentines/pickuplines.py
@@ -14,7 +14,7 @@ with open(Path('bot', 'resources', 'valentines', 'pickup_lines.json'), 'r', enco
     pickup_lines = load(f)
 
 
-class PickupLine:
+class PickupLine(commands.Cog):
     """A cog that gives random cheesy pickup lines."""
 
     def __init__(self, bot):

--- a/bot/seasons/valentines/savethedate.py
+++ b/bot/seasons/valentines/savethedate.py
@@ -16,7 +16,7 @@ with open(Path('bot', 'resources', 'valentines', 'date_ideas.json'), 'r', encodi
     VALENTINES_DATES = load(f)
 
 
-class SaveTheDate:
+class SaveTheDate(commands.Cog):
     """A cog that gives random suggestion for a Valentine's date."""
 
     def __init__(self, bot):

--- a/bot/seasons/valentines/valentine_zodiac.py
+++ b/bot/seasons/valentines/valentine_zodiac.py
@@ -14,7 +14,7 @@ LETTER_EMOJI = ':love_letter:'
 HEART_EMOJIS = [":heart:", ":gift_heart:", ":revolving_hearts:", ":sparkling_heart:", ":two_hearts:"]
 
 
-class ValentineZodiac:
+class ValentineZodiac(commands.Cog):
     """A cog that returns a counter compatible zodiac sign to the given user's zodiac sign."""
 
     def __init__(self, bot):

--- a/bot/seasons/valentines/whoisvalentine.py
+++ b/bot/seasons/valentines/whoisvalentine.py
@@ -14,7 +14,7 @@ with open(Path("bot", "resources", "valentines", "valentine_facts.json"), "r") a
     FACTS = json.load(file)
 
 
-class ValentineFacts:
+class ValentineFacts(commands.Cog):
     """A Cog for displaying facts about Saint Valentine."""
 
     def __init__(self, bot):


### PR DESCRIPTION
- Adds `commands.Cog` inheritance to cogs that are missing it.
- Update d.py version pin & relock
  - Codebase is unaffected by any of the current breaking changes that followed the Cog change
- Re-add the Cog inheritance that I accidentally removed when resolving the flake8 merge conflicts and didn't notice until it got merged
- Bump Easter season back one day to accommodate April Fools