### PR TITLE
Always announce if docstring, better formatting.

### DIFF
--- a/bot/seasons/season.py
+++ b/bot/seasons/season.py
@@ -17,6 +17,8 @@ from bot.decorators import with_role
 
 log = logging.getLogger(__name__)
 
+ICON_BASE_URL = "https://raw.githubusercontent.com/python-discord/branding/master"
+
 
 def get_seasons() -> List[str]:
     """
@@ -163,12 +165,11 @@ class SeasonBase:
         `https://raw.githubusercontent.com/python-discord/branding/master`
         """
 
-        base_url = "https://raw.githubusercontent.com/python-discord/branding/master"
         if avatar:
             icon = self.bot_icon or self.icon
         else:
             icon = self.icon
-        full_url = base_url + icon
+        full_url = ICON_BASE_URL + icon
         log.debug(f"Getting icon from: {full_url}")
         async with bot.http_session.get(full_url) as resp:
             return await resp.read()
@@ -288,6 +289,9 @@ class SeasonBase:
 
         embed = discord.Embed(description=f"{announce}\n\n", colour=self.colour or guild.me.colour)
         embed.set_author(name=self.greeting)
+
+        if self.icon:
+            embed.set_image(url=ICON_BASE_URL+self.icon)
 
         # find any seasonal commands
         cogs = []


### PR DESCRIPTION
Announcements were setup previously to not send anything if no seasonal commands were found. Since we want to announce regardless to entice people to contribute, I've adjusted the logic to always announce, but only add the commands info if there were any found.

There was also a formatting issue with newlines and wrapping that was a result of using the docstring which we explicitly make a newline for when it gets close to linting max length. The new formatting process takes a docstring, splits by paragraphs, and then replaces any newlines with a single space, letting single paragraph blocks wrap correctly in the announcement embed. Example:

**Docstring**
```py
    """
    Easter is a beautiful time of the year often celebrated after the first Full Moon of the new spring season.
    This time is quite beautiful due to the colorful flowers coming out to greet us. So. let's greet Spring
    in an Easter celebration of contributions.
    """
```
**Before**
![image](https://user-images.githubusercontent.com/29337040/55271831-40465500-52ff-11e9-8131-6c4eccc54160.png)
**After**
![image](https://user-images.githubusercontent.com/29337040/55271843-8d2a2b80-52ff-11e9-8c51-8b76600de65a.png)

