### PR TITLE
Improve easter announcement.

### DIFF
--- a/bot/seasons/easter/__init__.py
+++ b/bot/seasons/easter/__init__.py
@@ -3,17 +3,20 @@ from bot.seasons import SeasonBase
 
 class Easter(SeasonBase):
     """
-    Often celebrated after the first full moon of the Northern Hemisphere's new spring season,
-    Easter is a beautiful time of the year with colorful flowers coming out to greet us.
+    Here at Python Discord, we celebrate our version of Easter during the entire month of April.
+    While this celebration takes place, you'll notice a few changes:
 
-    To celebrate, we have a lovely new colourful server icon. Thanks to <@140605665772175361> for
-    the design.
+     • The server icon has changed to our Easter icon. Thanks to <@140605665772175361> for the
+    design!
 
-    We hope you can join us in the spring and Easter celebrations by heading over to the
-    [SeasonalBot GitHub repo](https://git.io/fjkvQ) and either submit some issues with ideas for
-    commands for this season, or to pick out an issue that you think looks fun to work on yourself.
+     • [Easter issues now available for SeasonalBot on the repo](https://git.io/fjkvQ).
 
-    Come over to <#542272993192050698> if you're interested or have any questions!
+     • You may see stuff like an Easter themed esoteric challenge, a celebration of Earth Day, or
+    Easter-related micro-events for you to join. Stay tuned!
+
+    If you'd like to contribute, head on over to <#542272993192050698> and we will help you get
+    started. It doesn't matter if you're new to open source or Python, if you'd like to help, we
+    will find you a task and teach you what you need to know.
     """
 
     name = "easter"

--- a/bot/seasons/easter/__init__.py
+++ b/bot/seasons/easter/__init__.py
@@ -3,9 +3,8 @@ from bot.seasons import SeasonBase
 
 class Easter(SeasonBase):
     """
-    Easter is a beautiful time of the year often celebrated after the first full moon of the
-    Northern Hemisphere's new spring season, making it a beautiful time of the year with colorful
-    flowers coming out to greet us.
+    Often celebrated after the first full moon of the Northern Hemisphere's new spring season,
+    Easter is a beautiful time of the year with colorful flowers coming out to greet us.
 
     To celebrate, we have a lovely new colourful server icon. Thanks to <@140605665772175361> for
     the design.

--- a/bot/seasons/easter/__init__.py
+++ b/bot/seasons/easter/__init__.py
@@ -3,12 +3,12 @@ from bot.seasons import SeasonBase
 
 class Easter(SeasonBase):
     """
-    To celebrate, we have a lovely new colourful server icon. Thanks to <@140605665772175361> for
-    the design.
-
     Easter is a beautiful time of the year often celebrated after the first full moon of the
     Northern Hemisphere's new spring season, making it a beautiful time of the year with colorful
     flowers coming out to greet us.
+
+    To celebrate, we have a lovely new colourful server icon. Thanks to <@140605665772175361> for
+    the design.
 
     We hope you can join us in the spring and Easter celebrations by heading over to the
     [SeasonalBot GitHub repo](https://git.io/fjkvQ) and either submit some issues with ideas for

--- a/bot/seasons/easter/__init__.py
+++ b/bot/seasons/easter/__init__.py
@@ -6,15 +6,15 @@ class Easter(SeasonBase):
     To celebrate, we have a lovely new colourful server icon. Thanks to <@140605665772175361> for
     the design.
 
-    Easter is a beautiful time of the year often celebrated after the first Full Moon of the
-    Northern Hemisphere's new spring seasonm, making it a beautiful time of the year with colorful
+    Easter is a beautiful time of the year often celebrated after the first full moon of the
+    Northern Hemisphere's new spring season, making it a beautiful time of the year with colorful
     flowers coming out to greet us.
 
-    We hope you can join us in the Spring and Easter celebrations by heading over to the
+    We hope you can join us in the spring and Easter celebrations by heading over to the
     [SeasonalBot GitHub repo](https://git.io/fjkvQ) and either submit some issues with ideas for
-    commands of this season, or to pick out an issue that you think looks fun to build yourself.
+    commands for this season, or to pick out an issue that you think looks fun to work on yourself.
 
-    Come over to <#542272993192050698> if you're interested or had any questions!
+    Come over to <#542272993192050698> if you're interested or have any questions!
     """
 
     name = "easter"

--- a/bot/seasons/easter/__init__.py
+++ b/bot/seasons/easter/__init__.py
@@ -3,14 +3,23 @@ from bot.seasons import SeasonBase
 
 class Easter(SeasonBase):
     """
-    Easter is a beautiful time of the year often celebrated after the first Full Moon of the new spring season.
-    This time is quite beautiful due to the colorful flowers coming out to greet us. So. let's greet Spring
-    in an Easter celebration of contributions.
+    To celebrate, we have a lovely new colourful server icon. Thanks to <@140605665772175361> for
+    the design.
+
+    Easter is a beautiful time of the year often celebrated after the first Full Moon of the
+    Northern Hemisphere's new spring seasonm, making it a beautiful time of the year with colorful
+    flowers coming out to greet us.
+
+    We hope you can join us in the Spring and Easter celebrations by heading over to the
+    [SeasonalBot GitHub repo](https://git.io/fjkvQ) and either submit some issues with ideas for
+    commands of this season, or to pick out an issue that you think looks fun to build yourself.
+
+    Come over to <#542272993192050698> if you're interested or had any questions!
     """
 
     name = "easter"
     bot_name = "BunnyBot"
-    greeting = "Happy Easter to us all!"
+    greeting = "Happy Easter!"
 
     # Duration of season
     start_date = "01/04"


### PR DESCRIPTION
This fleshes out the announcement to a proper one that's in line with our typical announcement style and info for these seasonal events.

It adds a mention about the server icon changing so less people ask why it's changed, a thanks to the person who chose the design colours, cleans the embed greeting to be less awkward and finally encourages people to actually join in the event itself by contributing or implementing ideas and popping into the seasonalbot chat channel to discuss the event.