### PR TITLE
Constants - Spring Cleaning

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -18,7 +18,6 @@ class AdventOfCode:
     leaderboard_join_code = str(environ.get("AOC_JOIN_CODE", None))
     leaderboard_max_displayed_members = 10
     year = 2018
-    channel_id = int(environ.get("AOC_CHANNEL_ID", 517745814039166986))
     role_id = int(environ.get("AOC_ROLE_ID", 518565788744024082))
 
 
@@ -84,12 +83,10 @@ class Emojis:
 
 
 class Lovefest:
-    channel_id = int(environ.get("LOVEFEST_CHANNEL_ID", 542272993192050698))
     role_id = int(environ.get("LOVEFEST_ROLE_ID", 542431903886606399))
 
 
 class Hacktoberfest(NamedTuple):
-    channel_id = 498804484324196362
     voice_id = 514420006474219521
 
 

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -13,7 +13,7 @@ from bs4 import BeautifulSoup
 from discord.ext import commands
 from pytz import timezone
 
-from bot.constants import AdventOfCode as AocConfig, Colours, Emojis, Tokens
+from bot.constants import AdventOfCode as AocConfig, Channels, Colours, Emojis, Tokens
 
 log = logging.getLogger(__name__)
 
@@ -88,7 +88,7 @@ async def day_countdown(bot: commands.Bot):
 
         await asyncio.sleep(time_left.seconds)
 
-        channel = bot.get_channel(AocConfig.channel_id)
+        channel = bot.get_channel(Channels.seasonalbot_chat)
 
         if not channel:
             log.error("Could not find the AoC channel to send notification in")

--- a/bot/seasons/halloween/candy_collection.py
+++ b/bot/seasons/halloween/candy_collection.py
@@ -7,7 +7,7 @@ import random
 import discord
 from discord.ext import commands
 
-from bot.constants import Hacktoberfest
+from bot.constants import Channels
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class CandyCollection(commands.Cog):
         if message.author.bot:
             return
         # ensure it's hacktober channel
-        if message.channel.id != Hacktoberfest.channel_id:
+        if message.channel.id != Channels.seasonalbot_chat:
             return
 
         # do random check for skull first as it has the lower chance
@@ -65,7 +65,7 @@ class CandyCollection(commands.Cog):
             return
 
         # check to ensure it is in correct channel
-        if message.channel.id != Hacktoberfest.channel_id:
+        if message.channel.id != Channels.seasonalbot_chat:
             return
 
         # if its not a candy or skull, and it is one of 10 most recent messages,
@@ -127,7 +127,7 @@ class CandyCollection(commands.Cog):
         ten_recent = []
         recent_msg = max(message.id for message
                          in self.bot._connection._messages
-                         if message.channel.id == Hacktoberfest.channel_id)
+                         if message.channel.id == Channels.seasonalbot_chat)
 
         channel = await self.hacktober_channel()
         ten_recent.append(recent_msg.id)
@@ -159,7 +159,7 @@ class CandyCollection(commands.Cog):
     async def hacktober_channel(self):
         """Get #hacktoberbot channel from its ID."""
 
-        return self.bot.get_channel(id=Hacktoberfest.channel_id)
+        return self.bot.get_channel(id=Channels.seasonalbot_chat)
 
     async def remove_reactions(self, reaction):
         """Remove all candy/skull reactions."""

--- a/bot/seasons/halloween/halloween_facts.py
+++ b/bot/seasons/halloween/halloween_facts.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import discord
 from discord.ext import commands
 
-from bot.constants import Hacktoberfest
+from bot.constants import Channels
 
 log = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class HalloweenFacts(commands.Cog):
     async def on_ready(self):
         """Get event Channel object and initialize fact task loop."""
 
-        self.channel = self.bot.get_channel(Hacktoberfest.channel_id)
+        self.channel = self.bot.get_channel(Channels.seasonalbot_chat)
         self.bot.loop.create_task(self._fact_publisher_task())
 
     def random_fact(self):

--- a/bot/seasons/valentines/be_my_valentine.py
+++ b/bot/seasons/valentines/be_my_valentine.py
@@ -8,7 +8,7 @@ import discord
 from discord.ext import commands
 from discord.ext.commands.cooldowns import BucketType
 
-from bot.constants import Client, Colours, Lovefest
+from bot.constants import Channels, Client, Colours, Lovefest
 
 log = logging.getLogger(__name__)
 
@@ -99,7 +99,7 @@ class BeMyValentine(commands.Cog):
 
         emoji_1, emoji_2 = self.random_emoji()
         lovefest_role = discord.utils.get(ctx.guild.roles, id=Lovefest.role_id)
-        channel = self.bot.get_channel(Lovefest.channel_id)
+        channel = self.bot.get_channel(Channels.seasonalbot_chat)
         valentine, title = self.valentine_check(valentine_type)
 
         if user is None:


### PR DESCRIPTION
---
name: Constant Clearing
about: Combining all the seasonal bot chat constants to one chat
Closes #192 

---

This PR removes any season-specific channel IDs and combines them into one `seasonalbot_chat` constant in `Channels`. 
This also changes any cogs which previously used the aforementioned channel IDs

Hope this is okay :D