### PR TITLE
Fixing the Snakes and Ladders game

### DIFF
--- a/bot/seasons/evergreen/snakes/utils.py
+++ b/bot/seasons/evergreen/snakes/utils.py
@@ -593,9 +593,8 @@ class SnakeAndLaddersGame:
             y_offset -= BOARD_PLAYER_SIZE * math.floor(i / player_row_size)
             board_img.paste(self.avatar_images[player.id],
                             box=(x_offset, y_offset))
-        stream = io.BytesIO()
-        board_img.save(stream, format='JPEG')
-        board_file = File(stream.getvalue(), filename='Board.jpg')
+
+        board_file = File(frame_to_png_bytes(board_img), filename='Board.jpg')
         player_list = '\n'.join((user.mention + ": Tile " + str(self.player_tiles[user.id])) for user in self.players)
 
         # Store and send new messages


### PR DESCRIPTION
The Snakes and Ladders game in the snake cog was broken because the BytesIO stream of the generated board image was handled incorrectly. This lead to the `ValueError: embedded null byte` exception we've seen before on another other older feature. (My guess is that a breaking change somewhere broke these relatively old pieces of code that did work before.)

I fixed it by replacing the lines handling the BytesIO stream with an existing utility function that does precisely what's needed and was already defined just above the lines containing the bug.