### PR TITLE
Limit SeasonalBot commands to whitelisted channels

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,9 +1,11 @@
 import logging
 
 from bot.bot import bot
-from bot.constants import Client
+from bot.constants import Client, STAFF_ROLES, WHITELISTED_CHANNELS
+from bot.decorators import in_channel_check
 
 log = logging.getLogger(__name__)
 
+bot.add_check(in_channel_check(*WHITELISTED_CHANNELS, bypass_roles=STAFF_ROLES))
 bot.load_extension("bot.seasons")
 bot.run(Client.token)

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,6 +1,7 @@
 import logging
 
-from bot.constants import Client, bot
+from bot.bot import bot
+from bot.constants import Client
 
 log = logging.getLogger(__name__)
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -7,11 +7,11 @@ from aiohttp import AsyncResolver, ClientSession, TCPConnector
 from discord import Embed
 from discord.ext import commands
 
-from bot import constants
+from bot.constants import Channels, Client
 
 log = logging.getLogger(__name__)
 
-__all__ = ('SeasonalBot',)
+__all__ = ('SeasonalBot', 'bot')
 
 
 class SeasonalBot(commands.Bot):
@@ -42,7 +42,7 @@ class SeasonalBot(commands.Bot):
 
     async def send_log(self, title: str, details: str = None, *, icon: str = None):
         """Send an embed message to the devlog channel."""
-        devlog = self.get_channel(constants.Channels.devlog)
+        devlog = self.get_channel(Channels.devlog)
 
         if not devlog:
             log.warning("Log failed to send. Devlog channel not found.")
@@ -62,3 +62,6 @@ class SeasonalBot(commands.Bot):
             context.command.reset_cooldown(context)
         else:
             await super().on_command_error(context, exception)
+
+
+bot = SeasonalBot(command_prefix=Client.prefix)

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -3,8 +3,9 @@ from os import environ
 from typing import NamedTuple
 
 __all__ = (
-    "AdventOfCode", "Channels", "Client", "Colours", "Emojis", "Hacktoberfest", "Roles",
-    "Tokens", "ERROR_REPLIES",
+    "AdventOfCode", "Channels", "Client", "Colours", "Emojis", "Hacktoberfest", "Roles", "Tokens",
+    "WHITELISTED_CHANNELS", "STAFF_ROLES", "MODERATION_ROLES",
+    "POSITIVE_REPLIES", "NEGATIVE_REPLIES", "ERROR_REPLIES",
 )
 
 log = logging.getLogger(__name__)
@@ -115,6 +116,58 @@ class Tokens(NamedTuple):
     omdb = environ.get("OMDB_API_KEY")
     youtube = environ.get("YOUTUBE_API_KEY")
 
+
+# Default role combinations
+MODERATION_ROLES = Roles.moderator, Roles.admin, Roles.owner
+STAFF_ROLES = Roles.helpers, Roles.moderator, Roles.admin, Roles.owner
+
+# Whitelisted channels
+WHITELISTED_CHANNELS = (
+    Channels.bot, Channels.seasonalbot_commands,
+    Channels.off_topic_0, Channels.off_topic_1, Channels.off_topic_2,
+    Channels.devtest,
+)
+
+# Bot replies
+NEGATIVE_REPLIES = [
+    "Noooooo!!",
+    "Nope.",
+    "I'm sorry Dave, I'm afraid I can't do that.",
+    "I don't think so.",
+    "Not gonna happen.",
+    "Out of the question.",
+    "Huh? No.",
+    "Nah.",
+    "Naw.",
+    "Not likely.",
+    "No way, José.",
+    "Not in a million years.",
+    "Fat chance.",
+    "Certainly not.",
+    "NEGATORY.",
+    "Nuh-uh.",
+    "Not in my house!",
+]
+
+POSITIVE_REPLIES = [
+    "Yep.",
+    "Absolutely!",
+    "Can do!",
+    "Affirmative!",
+    "Yeah okay.",
+    "Sure.",
+    "Sure thing!",
+    "You're the boss!",
+    "Okay.",
+    "No problem.",
+    "I got you.",
+    "Alright.",
+    "You got it!",
+    "ROGER THAT",
+    "Of course!",
+    "Aye aye, cap'n!",
+    "I'll allow it.",
+]
 
 ERROR_REPLIES = [
     "Please don't do that.",

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -2,11 +2,9 @@ import logging
 from os import environ
 from typing import NamedTuple
 
-from bot.bot import SeasonalBot
-
 __all__ = (
     "AdventOfCode", "Channels", "Client", "Colours", "Emojis", "Hacktoberfest", "Roles",
-    "Tokens", "ERROR_REPLIES", "bot"
+    "Tokens", "ERROR_REPLIES",
 )
 
 log = logging.getLogger(__name__)
@@ -130,6 +128,3 @@ ERROR_REPLIES = [
     "Noooooo!!",
     "I can't believe you've done this",
 ]
-
-
-bot = SeasonalBot(command_prefix=Client.prefix)

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -24,8 +24,10 @@ def with_role(*role_ids: int):
     """Check to see whether the invoking user has any of the roles specified in role_ids."""
     async def predicate(ctx: Context):
         if not ctx.guild:  # Return False in a DM
-            log.debug(f"{ctx.author} tried to use the '{ctx.command.name}'command from a DM. "
-                      "This command is restricted by the with_role decorator. Rejecting request.")
+            log.debug(
+                f"{ctx.author} tried to use the '{ctx.command.name}'command from a DM. "
+                "This command is restricted by the with_role decorator. Rejecting request."
+            )
             return False
 
         for role in ctx.author.roles:
@@ -33,8 +35,10 @@ def with_role(*role_ids: int):
                 log.debug(f"{ctx.author} has the '{role.name}' role, and passes the check.")
                 return True
 
-        log.debug(f"{ctx.author} does not have the required role to use "
-                  f"the '{ctx.command.name}' command, so the request is rejected.")
+        log.debug(
+            f"{ctx.author} does not have the required role to use "
+            f"the '{ctx.command.name}' command, so the request is rejected."
+        )
         return False
     return commands.check(predicate)
 
@@ -43,14 +47,18 @@ def without_role(*role_ids: int):
     """Check whether the invoking user does not have all of the roles specified in role_ids."""
     async def predicate(ctx: Context):
         if not ctx.guild:  # Return False in a DM
-            log.debug(f"{ctx.author} tried to use the '{ctx.command.name}' command from a DM. "
-                      "This command is restricted by the without_role decorator. Rejecting request.")
+            log.debug(
+                f"{ctx.author} tried to use the '{ctx.command.name}' command from a DM. "
+                "This command is restricted by the without_role decorator. Rejecting request."
+            )
             return False
 
         author_roles = [role.id for role in ctx.author.roles]
         check = all(role not in author_roles for role in role_ids)
-        log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
-                  f"The result of the without_role check was {check}.")
+        log.debug(
+            f"{ctx.author} tried to call the '{ctx.command.name}' command. "
+            f"The result of the without_role check was {check}."
+        )
         return check
     return commands.check(predicate)
 
@@ -63,25 +71,30 @@ def in_channel_check(*channels: int, bypass_roles: typing.Container[int] = None)
             return True
 
         if ctx.channel.id in channels:
-            log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
-                      f"The command was used in a whitelisted channel.")
+            log.debug(
+                f"{ctx.author} tried to call the '{ctx.command.name}' command "
+                f"and the command was used in a whitelisted channel."
+            )
             return True
 
         if hasattr(ctx.command.callback, "in_channel_override"):
-            log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
-                      f"The command was not used in a whitelisted channel, "
-                      f"but the command was whitelisted to bypass the in_channel check.")
+            log.debug(
+                f"{ctx.author} called the '{ctx.command.name}' command "
+                f"and the command was whitelisted to bypass the in_channel check."
+            )
             return True
 
-        if bypass_roles:
-            if any(r.id in bypass_roles for r in ctx.author.roles):
-                log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
-                          f"The command was not used in a whitelisted channel, "
-                          f"but the author had a role to bypass the in_channel check.")
-                return True
+        if bypass_roles and any(r.id in bypass_roles for r in ctx.author.roles):
+            log.debug(
+                f"{ctx.author} called the '{ctx.command.name}' command and "
+                f"had a role to bypass the in_channel check."
+            )
+            return True
 
-        log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
-                  f"The in_channel check failed.")
+        log.debug(
+            f"{ctx.author} tried to call the '{ctx.command.name}' command. "
+            f"The in_channel check failed."
+        )
 
         channels_str = ', '.join(f"<#{c_id}>" for c_id in channels)
         raise InChannelCheckFailure(

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -14,6 +14,7 @@ from discord.ext import commands
 from pytz import timezone
 
 from bot.constants import AdventOfCode as AocConfig, Channels, Colours, Emojis, Tokens
+from bot.decorators import override_in_channel
 
 log = logging.getLogger(__name__)
 
@@ -125,6 +126,7 @@ class AdventOfCode(commands.Cog):
         self.status_task = asyncio.ensure_future(self.bot.loop.create_task(status_coro))
 
     @commands.group(name="adventofcode", aliases=("aoc",), invoke_without_command=True)
+    @override_in_channel
     async def adventofcode_group(self, ctx: commands.Context):
         """All of the Advent of Code commands."""
         await ctx.send_help(ctx.command)

--- a/bot/seasons/easter/egg_hunt/cog.py
+++ b/bot/seasons/easter/egg_hunt/cog.py
@@ -9,7 +9,8 @@ from pathlib import Path
 import discord
 from discord.ext import commands
 
-from bot.constants import Channels, Client, Roles as MainRoles, bot
+from bot.bot import bot
+from bot.constants import Channels, Client, Roles as MainRoles
 from bot.decorators import with_role
 from .constants import Colours, EggHuntSettings, Emoji, Roles
 

--- a/bot/seasons/easter/egg_hunt/constants.py
+++ b/bot/seasons/easter/egg_hunt/constants.py
@@ -2,7 +2,8 @@ import os
 
 from discord import Colour
 
-from bot.constants import Channels, Client, bot
+from bot.bot import bot
+from bot.constants import Channels, Client
 
 
 GUILD = bot.get_guild(Client.guild)

--- a/bot/seasons/evergreen/error_handler.py
+++ b/bot/seasons/evergreen/error_handler.py
@@ -1,9 +1,14 @@
 import logging
 import math
+import random
 import sys
 import traceback
 
+from discord import Colour, Embed
 from discord.ext import commands
+
+from bot.constants import NEGATIVE_REPLIES
+from bot.decorators import InChannelCheckFailure
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +38,16 @@ class CommandErrorHandler(commands.Cog):
             )
 
         error = getattr(error, 'original', error)
+
+        if isinstance(error, InChannelCheckFailure):
+            logging.debug(
+                f"{ctx.author} the command '{ctx.command}', but they did not have "
+                f"permissions to run commands in the channel {ctx.channel}!"
+            )
+            embed = Embed(colour=Colour.red())
+            embed.title = random.choice(NEGATIVE_REPLIES)
+            embed.description = str(error)
+            return await ctx.send(embed=embed)
 
         if isinstance(error, commands.CommandNotFound):
             return logging.debug(

--- a/bot/seasons/evergreen/issues.py
+++ b/bot/seasons/evergreen/issues.py
@@ -4,6 +4,7 @@ import discord
 from discord.ext import commands
 
 from bot.constants import Colours
+from bot.decorators import override_in_channel
 
 log = logging.getLogger(__name__)
 
@@ -15,6 +16,7 @@ class Issues(commands.Cog):
         self.bot = bot
 
     @commands.command(aliases=("issues",))
+    @override_in_channel
     async def issue(self, ctx, number: int, repository: str = "seasonalbot", user: str = "python-discord"):
         """Command to retrieve issues from a GitHub repository."""
         api_url = f"https://api.github.com/repos/{user}/{repository}/issues/{number}"

--- a/bot/seasons/season.py
+++ b/bot/seasons/season.py
@@ -12,7 +12,8 @@ import async_timeout
 import discord
 from discord.ext import commands
 
-from bot.constants import Channels, Client, Roles, bot
+from bot.bot import bot
+from bot.constants import Channels, Client, Roles
 from bot.decorators import with_role
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
This PR restricts SeasonalBot commands to these channels:
* bot-commands, seasonalbot_commands
* ot0, ot1 and ot2 channels
* dev-test

To do so, functionality was added `in_channel` to allow a list of roles that bypass the check. The predicate function and the actual `discord.ext.commands.check` was separated so the predicate can be added as a global check to the bot.

The `in_channel` check can be overriden for certain commands using a decorator. Commands that currently have the override are `!issue` and `!adventofcode`.

To avoid circular imports, the bot instance definition was moved to the same file as the `SeasonalBot` class, `bot.py`. 

Constants brought over from the Python bot:
* MODERATION_ROLES, STAFF_ROLES
* NEGATIVE_REPLIES, POSITIVE_REPLIES