### PR TITLE
Add RecommendGame cog and resources

### DIFF
--- a/bot/resources/evergreen/game_recs/chrono_trigger.json
+++ b/bot/resources/evergreen/game_recs/chrono_trigger.json
@@ -1,7 +1,7 @@
 {
   "title": "Chrono Trigger",
-  "recText": "One of the best games of all time. A brilliant story involving time-travel with loveable characters. It has a brilliant score by Yasonuri Mitsuda and artwork by Akira Toriyama. With over 20 endings and New Game+, there is a huge amount of replay value here.",
-  "wikiLink": "https://rawg.io/games/chrono-trigger-1995",
+  "description": "One of the best games of all time. A brilliant story involving time-travel with loveable characters. It has a brilliant score by Yasonuri Mitsuda and artwork by Akira Toriyama. With over 20 endings and New Game+, there is a huge amount of replay value here.",
+  "link": "https://rawg.io/games/chrono-trigger-1995",
   "image": "https://vignette.wikia.nocookie.net/chrono/images/2/24/Chrono_Trigger_cover.jpg",
   "author": "352635617709916161"
 }

--- a/bot/resources/evergreen/game_recs/chrono_trigger.json
+++ b/bot/resources/evergreen/game_recs/chrono_trigger.json
@@ -1,0 +1,10 @@
+{
+  "title": "Chrono Trigger",
+  "recText": "My personal favorite game of all time. Square + Enix + Akira Toriyama = Pure Time-traveling gold.",
+  "console": [
+    "snes",
+    "gba",
+    "pc"
+  ],
+  "image": "https://vignette.wikia.nocookie.net/chrono/images/2/24/Chrono_Trigger_cover.jpg"
+}

--- a/bot/resources/evergreen/game_recs/chrono_trigger.json
+++ b/bot/resources/evergreen/game_recs/chrono_trigger.json
@@ -1,10 +1,12 @@
 {
   "title": "Chrono Trigger",
-  "recText": "My personal favorite game of all time. Square + Enix + Akira Toriyama = Pure Time-traveling gold.",
+  "recText": "One of the best games of all time. A brilliant story involving time-travel with loveable characters. It has a brilliant score by Yasonuri Mitsuda and artwork by Akira Toriyama. With over 20 endings and New Game+, there is a huge amount of replay value here.",
   "console": [
     "snes",
     "gba",
     "pc"
   ],
-  "image": "https://vignette.wikia.nocookie.net/chrono/images/2/24/Chrono_Trigger_cover.jpg"
+  "wikiLink": "https://chrono.fandom.com/wiki/Chrono_Trigger",
+  "image": "https://vignette.wikia.nocookie.net/chrono/images/2/24/Chrono_Trigger_cover.jpg",
+  "author": "352635617709916161"
 }

--- a/bot/resources/evergreen/game_recs/chrono_trigger.json
+++ b/bot/resources/evergreen/game_recs/chrono_trigger.json
@@ -1,12 +1,7 @@
 {
   "title": "Chrono Trigger",
   "recText": "One of the best games of all time. A brilliant story involving time-travel with loveable characters. It has a brilliant score by Yasonuri Mitsuda and artwork by Akira Toriyama. With over 20 endings and New Game+, there is a huge amount of replay value here.",
-  "console": [
-    "snes",
-    "gba",
-    "pc"
-  ],
-  "wikiLink": "https://chrono.fandom.com/wiki/Chrono_Trigger",
+  "wikiLink": "https://rawg.io/games/chrono-trigger-1995",
   "image": "https://vignette.wikia.nocookie.net/chrono/images/2/24/Chrono_Trigger_cover.jpg",
   "author": "352635617709916161"
 }

--- a/bot/resources/evergreen/game_recs/digimon_world.json
+++ b/bot/resources/evergreen/game_recs/digimon_world.json
@@ -1,10 +1,7 @@
 {
   "title": "Digimon World",
-  "recText": "A great mix of town-building and pet-raising set in the Digimon universe.",
-  "console": [
-    "ps1"
-  ],
+  "recText": "A great mix of town-building and pet-raising set in the Digimon universe. With plenty of Digimon to raise and recruit to the village, this charming game will keep you occupied for a long time.",
   "image": "https://www.mobygames.com/images/covers/l/437308-digimon-world-playstation-front-cover.jpg",
-  "wikiLink": "https://digimon.fandom.com/wiki/Digimon_World",
+  "wikiLink": "https://rawg.io/games/digimon-world",
   "author": "352635617709916161"
 }

--- a/bot/resources/evergreen/game_recs/digimon_world.json
+++ b/bot/resources/evergreen/game_recs/digimon_world.json
@@ -1,0 +1,8 @@
+{
+  "title": "Digimon World",
+  "recText": "A great mix of town-building and pet-raising set in the Digimon universe.",
+  "console": [
+    "ps1"
+  ],
+  "image": "https://www.mobygames.com/images/covers/l/437308-digimon-world-playstation-front-cover.jpg"
+}

--- a/bot/resources/evergreen/game_recs/digimon_world.json
+++ b/bot/resources/evergreen/game_recs/digimon_world.json
@@ -1,7 +1,7 @@
 {
   "title": "Digimon World",
-  "recText": "A great mix of town-building and pet-raising set in the Digimon universe. With plenty of Digimon to raise and recruit to the village, this charming game will keep you occupied for a long time.",
+  "description": "A great mix of town-building and pet-raising set in the Digimon universe. With plenty of Digimon to raise and recruit to the village, this charming game will keep you occupied for a long time.",
   "image": "https://www.mobygames.com/images/covers/l/437308-digimon-world-playstation-front-cover.jpg",
-  "wikiLink": "https://rawg.io/games/digimon-world",
+  "link": "https://rawg.io/games/digimon-world",
   "author": "352635617709916161"
 }

--- a/bot/resources/evergreen/game_recs/digimon_world.json
+++ b/bot/resources/evergreen/game_recs/digimon_world.json
@@ -4,5 +4,7 @@
   "console": [
     "ps1"
   ],
-  "image": "https://www.mobygames.com/images/covers/l/437308-digimon-world-playstation-front-cover.jpg"
+  "image": "https://www.mobygames.com/images/covers/l/437308-digimon-world-playstation-front-cover.jpg",
+  "wikiLink": "https://digimon.fandom.com/wiki/Digimon_World",
+  "author": "352635617709916161"
 }

--- a/bot/resources/evergreen/game_recs/doom_2.json
+++ b/bot/resources/evergreen/game_recs/doom_2.json
@@ -1,0 +1,7 @@
+{
+  "title": "Doom II",
+  "recText": "Doom 2 was one of the first FPS games that I truly enjoyed. It offered awesome weapons, terrifying demons to kill, and a great atmosphere to do it in.",
+  "image": "https://upload.wikimedia.org/wikipedia/en/thumb/2/29/Doom_II_-_Hell_on_Earth_Coverart.png/220px-Doom_II_-_Hell_on_Earth_Coverart.png",
+  "wikiLink": "https://rawg.io/games/doom-ii",
+  "author": "352635617709916161"
+}

--- a/bot/resources/evergreen/game_recs/doom_2.json
+++ b/bot/resources/evergreen/game_recs/doom_2.json
@@ -1,7 +1,7 @@
 {
   "title": "Doom II",
-  "recText": "Doom 2 was one of the first FPS games that I truly enjoyed. It offered awesome weapons, terrifying demons to kill, and a great atmosphere to do it in.",
+  "description": "Doom 2 was one of the first FPS games that I truly enjoyed. It offered awesome weapons, terrifying demons to kill, and a great atmosphere to do it in.",
   "image": "https://upload.wikimedia.org/wikipedia/en/thumb/2/29/Doom_II_-_Hell_on_Earth_Coverart.png/220px-Doom_II_-_Hell_on_Earth_Coverart.png",
-  "wikiLink": "https://rawg.io/games/doom-ii",
+  "link": "https://rawg.io/games/doom-ii",
   "author": "352635617709916161"
 }

--- a/bot/resources/evergreen/game_recs/skyrim.json
+++ b/bot/resources/evergreen/game_recs/skyrim.json
@@ -1,0 +1,13 @@
+{
+  "title": "Elder Scrolls V: Skyrim",
+  "recText": "The last mainline Elder Scrolls game offered a fantastic role-playing experience with untethered freedom and a great story",
+  "console": [
+    "xbox 360",
+    "ps3",
+    "pc",
+    "nintendo switch",
+    "xbox one",
+    "ps4"
+  ],
+  "image": "https://upload.wikimedia.org/wikipedia/en/1/15/The_Elder_Scrolls_V_Skyrim_cover.png"
+}

--- a/bot/resources/evergreen/game_recs/skyrim.json
+++ b/bot/resources/evergreen/game_recs/skyrim.json
@@ -1,15 +1,7 @@
 {
   "title": "Elder Scrolls V: Skyrim",
   "recText": "The latest mainline Elder Scrolls game offered a fantastic role-playing experience with untethered freedom and a great story. Offering vast mod support, the game has endless customization and replay value.",
-  "console": [
-    "xbox 360",
-    "ps3",
-    "pc",
-    "nintendo switch",
-    "xbox one",
-    "ps4"
-  ],
   "image": "https://upload.wikimedia.org/wikipedia/en/1/15/The_Elder_Scrolls_V_Skyrim_cover.png",
-  "wikiLink": "https://elderscrolls.fandom.com/wiki/Skyrim",
+  "wikiLink": "https://rawg.io/games/the-elder-scrolls-v-skyrim",
   "author": "352635617709916161"
 }

--- a/bot/resources/evergreen/game_recs/skyrim.json
+++ b/bot/resources/evergreen/game_recs/skyrim.json
@@ -1,6 +1,6 @@
 {
   "title": "Elder Scrolls V: Skyrim",
-  "recText": "The last mainline Elder Scrolls game offered a fantastic role-playing experience with untethered freedom and a great story",
+  "recText": "The latest mainline Elder Scrolls game offered a fantastic role-playing experience with untethered freedom and a great story. Offering vast mod support, the game has endless customization and replay value.",
   "console": [
     "xbox 360",
     "ps3",
@@ -9,5 +9,7 @@
     "xbox one",
     "ps4"
   ],
-  "image": "https://upload.wikimedia.org/wikipedia/en/1/15/The_Elder_Scrolls_V_Skyrim_cover.png"
+  "image": "https://upload.wikimedia.org/wikipedia/en/1/15/The_Elder_Scrolls_V_Skyrim_cover.png",
+  "wikiLink": "https://elderscrolls.fandom.com/wiki/Skyrim",
+  "author": "352635617709916161"
 }

--- a/bot/resources/evergreen/game_recs/skyrim.json
+++ b/bot/resources/evergreen/game_recs/skyrim.json
@@ -1,7 +1,7 @@
 {
   "title": "Elder Scrolls V: Skyrim",
-  "recText": "The latest mainline Elder Scrolls game offered a fantastic role-playing experience with untethered freedom and a great story. Offering vast mod support, the game has endless customization and replay value.",
+  "description": "The latest mainline Elder Scrolls game offered a fantastic role-playing experience with untethered freedom and a great story. Offering vast mod support, the game has endless customization and replay value.",
   "image": "https://upload.wikimedia.org/wikipedia/en/1/15/The_Elder_Scrolls_V_Skyrim_cover.png",
-  "wikiLink": "https://rawg.io/games/the-elder-scrolls-v-skyrim",
+  "link": "https://rawg.io/games/the-elder-scrolls-v-skyrim",
   "author": "352635617709916161"
 }

--- a/bot/seasons/evergreen/recommend_game.py
+++ b/bot/seasons/evergreen/recommend_game.py
@@ -1,0 +1,56 @@
+import json
+import logging
+import os
+from pathlib import Path
+from random import shuffle
+
+import discord
+from discord.ext import commands
+
+log = logging.getLogger(__name__)
+DIR = "bot/resources/evergreen/game_recs"
+game_recs = []
+
+
+class RecommendGame(commands.Cog):
+    """Commands related to recommending games."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.populate_recs()
+
+    @commands.command(name="recommend_game")
+    async def recommend_game(self, ctx):
+        """Sends an Embed of a random game recommendation."""
+        if not game_recs:
+            self.populate_recs()
+            game = game_recs.pop()
+        else:
+            game = game_recs.pop()
+
+        embed = discord.Embed(
+            title=game['title'],
+            url=game['wikiLink'],
+            color=discord.Colour.blue()
+        )
+
+        author = self.bot.get_user(int(game['author']))
+        embed.set_author(name=author.name, icon_url=author.avatar_url)
+        embed.set_image(url=game['image'])
+        embed.add_field(name="Recommendation", value=game['recText'])
+
+        await ctx.send(embed=embed)
+
+    def populate_recs(self):
+        """Populates the game_recs list from resources."""
+        for file_url in os.listdir(DIR):
+            with Path(DIR, file_url).open(encoding='utf-8') as file:
+                data = json.load(file)
+            game_recs.append(data)
+        shuffle(game_recs)
+
+
+def setup(bot):
+    """Loads the RecommendGame cog."""
+    bot.add_cog(RecommendGame(bot))
+    log.info("Recommend_Game cog loaded")

--- a/bot/seasons/evergreen/recommend_game.py
+++ b/bot/seasons/evergreen/recommend_game.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from pathlib import Path
 from random import shuffle
 
@@ -8,8 +7,15 @@ import discord
 from discord.ext import commands
 
 log = logging.getLogger(__name__)
-DIR = "bot/resources/evergreen/game_recs"
+DIR = Path("bot/resources/evergreen/game_recs")
 game_recs = []
+
+# Populate the list `game_recs` with resource files
+for file_url in DIR.glob("*.json"):
+    with Path(file_url).open(encoding='utf-8') as file:
+        data = json.load(file)
+    game_recs.append(data)
+shuffle(game_recs)
 
 
 class RecommendGame(commands.Cog):
@@ -17,16 +23,20 @@ class RecommendGame(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
-        self.populate_recs()
+        self.index = 0
 
-    @commands.command(name="recommend_game")
+    @commands.command(name="recommend_game", aliases=['gameRec', 'recommendGame'])
     async def recommend_game(self, ctx):
         """Sends an Embed of a random game recommendation."""
-        if not game_recs:
-            self.populate_recs()
-            game = game_recs.pop()
+        if self.index < len(game_recs):
+            game = game_recs[self.index]
+            self.index += 1
         else:
-            game = game_recs.pop()
+            self.index = 0
+            shuffle(game_recs)
+            game = game_recs[self.index]
+            self.index += 1
+
         author = self.bot.get_user(int(game['author']))
 
         # Creating and formatting Embed
@@ -37,16 +47,8 @@ class RecommendGame(commands.Cog):
 
         await ctx.send(embed=embed)
 
-    def populate_recs(self):
-        """Populates the list `game_recs` from resources."""
-        for file_url in os.listdir(DIR):
-            with Path(DIR, file_url).open(encoding='utf-8') as file:
-                data = json.load(file)
-            game_recs.append(data)
-        shuffle(game_recs)
-
 
 def setup(bot):
     """Loads the RecommendGame cog."""
     bot.add_cog(RecommendGame(bot))
-    log.info("Recommend_Game cog loaded")
+    log.info("RecommendGame cog loaded")

--- a/bot/seasons/evergreen/recommend_game.py
+++ b/bot/seasons/evergreen/recommend_game.py
@@ -20,12 +20,12 @@ shuffle(game_recs)
 class RecommendGame(commands.Cog):
     """Commands related to recommending games."""
 
-    def __init__(self, bot):
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         self.index = 0
 
     @commands.command(name="recommendgame", aliases=['gamerec'])
-    async def recommend_game(self, ctx):
+    async def recommend_game(self, ctx: commands.Context) -> None:
         """Sends an Embed of a random game recommendation."""
         if self.index >= len(game_recs):
             self.index = 0
@@ -45,7 +45,7 @@ class RecommendGame(commands.Cog):
         await ctx.send(embed=embed)
 
 
-def setup(bot):
+def setup(bot: commands.Bot) -> None:
     """Loads the RecommendGame cog."""
     bot.add_cog(RecommendGame(bot))
     log.info("RecommendGame cog loaded")

--- a/bot/seasons/evergreen/recommend_game.py
+++ b/bot/seasons/evergreen/recommend_game.py
@@ -27,22 +27,18 @@ class RecommendGame(commands.Cog):
             game = game_recs.pop()
         else:
             game = game_recs.pop()
-
-        embed = discord.Embed(
-            title=game['title'],
-            url=game['wikiLink'],
-            color=discord.Colour.blue()
-        )
-
         author = self.bot.get_user(int(game['author']))
+
+        # Creating and formatting Embed
+        embed = discord.Embed(color=discord.Colour.blue())
         embed.set_author(name=author.name, icon_url=author.avatar_url)
         embed.set_image(url=game['image'])
-        embed.add_field(name="Recommendation", value=game['recText'])
+        embed.add_field(name='Recommendation: ' + game['title'] + '\n' + game['wikiLink'], value=game['recText'])
 
         await ctx.send(embed=embed)
 
     def populate_recs(self):
-        """Populates the game_recs list from resources."""
+        """Populates the list `game_recs` from resources."""
         for file_url in os.listdir(DIR):
             with Path(DIR, file_url).open(encoding='utf-8') as file:
                 data = json.load(file)

--- a/bot/seasons/evergreen/recommend_game.py
+++ b/bot/seasons/evergreen/recommend_game.py
@@ -37,7 +37,8 @@ class RecommendGame(commands.Cog):
 
         # Creating and formatting Embed
         embed = discord.Embed(color=discord.Colour.blue())
-        embed.set_author(name=author.name, icon_url=author.avatar_url)
+        if author is not None:
+            embed.set_author(name=author.name, icon_url=author.avatar_url)
         embed.set_image(url=game['image'])
         embed.add_field(name='Recommendation: ' + game['title'] + '\n' + game['link'], value=game['description'])
 

--- a/bot/seasons/evergreen/recommend_game.py
+++ b/bot/seasons/evergreen/recommend_game.py
@@ -7,12 +7,11 @@ import discord
 from discord.ext import commands
 
 log = logging.getLogger(__name__)
-DIR = Path("bot/resources/evergreen/game_recs")
 game_recs = []
 
 # Populate the list `game_recs` with resource files
-for file_url in DIR.glob("*.json"):
-    with Path(file_url).open(encoding='utf-8') as file:
+for rec_path in Path("bot/resources/evergreen/game_recs").glob("*.json"):
+    with rec_path.open(encoding='utf-8') as file:
         data = json.load(file)
     game_recs.append(data)
 shuffle(game_recs)
@@ -25,17 +24,14 @@ class RecommendGame(commands.Cog):
         self.bot = bot
         self.index = 0
 
-    @commands.command(name="recommend_game", aliases=['gameRec', 'recommendGame'])
+    @commands.command(name="recommendgame", aliases=['gamerec'])
     async def recommend_game(self, ctx):
         """Sends an Embed of a random game recommendation."""
-        if self.index < len(game_recs):
-            game = game_recs[self.index]
-            self.index += 1
-        else:
+        if self.index >= len(game_recs):
             self.index = 0
             shuffle(game_recs)
-            game = game_recs[self.index]
-            self.index += 1
+        game = game_recs[self.index]
+        self.index += 1
 
         author = self.bot.get_user(int(game['author']))
 
@@ -43,7 +39,7 @@ class RecommendGame(commands.Cog):
         embed = discord.Embed(color=discord.Colour.blue())
         embed.set_author(name=author.name, icon_url=author.avatar_url)
         embed.set_image(url=game['image'])
-        embed.add_field(name='Recommendation: ' + game['title'] + '\n' + game['wikiLink'], value=game['recText'])
+        embed.add_field(name='Recommendation: ' + game['title'] + '\n' + game['link'], value=game['description'])
 
         await ctx.send(embed=embed)
 


### PR DESCRIPTION
Created the RecommendGame cog with `.recommend_game` command as well as a new directory, `bot/resources/evergreen/game_recs`, for game recommendation files in .json to be stored and used by the cog. I added 4 different game recommendations to start with.
Current Embed formatting is as such:
![gameRecTest](https://user-images.githubusercontent.com/39713480/63129904-cc8fa680-bf86-11e9-9758-975350ac03ea.PNG)
