### PR TITLE
Hacktoberfest update & SaL Fix

### DIFF
--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -359,7 +359,7 @@ class AdventOfCode(commands.Cog):
             )
 
     async def _check_n_entries(self, ctx: commands.Context, number_of_people_to_display: int) -> int:
-        """Check for n > max_entries and n <= 0"""
+        """Check for n > max_entries and n <= 0."""
         max_entries = AocConfig.leaderboard_max_displayed_members
         author = ctx.message.author
         if not 0 <= number_of_people_to_display <= max_entries:

--- a/bot/seasons/easter/avatar_easterifier.py
+++ b/bot/seasons/easter/avatar_easterifier.py
@@ -34,7 +34,7 @@ class AvatarEasterifier(commands.Cog):
         r1, g1, b1 = x
 
         def distance(point):
-            """Finds the difference between a pastel colour and the original pixel colour"""
+            """Finds the difference between a pastel colour and the original pixel colour."""
             r2, g2, b2 = point
             return ((r1 - r2)**2 + (g1 - g2)**2 + (b1 - b2)**2)
 

--- a/bot/seasons/easter/bunny_name_generator.py
+++ b/bot/seasons/easter/bunny_name_generator.py
@@ -28,8 +28,8 @@ class BunnyNameGenerator(commands.Cog):
         """
         Finds vowels in the user's display name.
 
-        If the Discord name contains a vowel and the letter y,
-        it will match one or more of these patterns.
+        If the Discord name contains a vowel and the letter y, it will match one or more of these patterns.
+
         Only the most recently matched pattern will apply the changes.
         """
         expressions = [
@@ -46,7 +46,7 @@ class BunnyNameGenerator(commands.Cog):
                 return new_name
 
     def append_name(self, displayname):
-        """Adds a suffix to the end of the Discord name"""
+        """Adds a suffix to the end of the Discord name."""
         extensions = ['foot', 'ear', 'nose', 'tail']
         suffix = random.choice(extensions)
         appended_name = displayname + suffix
@@ -55,12 +55,12 @@ class BunnyNameGenerator(commands.Cog):
 
     @commands.command()
     async def bunnyname(self, ctx):
-        """Picks a random bunny name from a JSON file"""
+        """Picks a random bunny name from a JSON file."""
         await ctx.send(random.choice(BUNNY_NAMES["names"]))
 
     @commands.command()
     async def bunnifyme(self, ctx):
-        """Gets your Discord username and bunnifies it"""
+        """Gets your Discord username and bunnifies it."""
         username = ctx.message.author.display_name
 
         # If name contains spaces or other separators, get the individual words to randomly bunnify

--- a/bot/seasons/easter/easter_riddle.py
+++ b/bot/seasons/easter/easter_riddle.py
@@ -84,7 +84,7 @@ class EasterRiddle(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
-        """If a non-bot user enters a correct answer, their username gets added to self.winners"""
+        """If a non-bot user enters a correct answer, their username gets added to self.winners."""
         if self.current_channel != message.channel:
             return
 

--- a/bot/seasons/easter/egghead_quiz.py
+++ b/bot/seasons/easter/egghead_quiz.py
@@ -37,7 +37,7 @@ class EggheadQuiz(commands.Cog):
     @commands.command(aliases=["eggheadquiz", "easterquiz"])
     async def eggquiz(self, ctx):
         """
-        Gives a random quiz question, waits 30 seconds and then outputs the answer
+        Gives a random quiz question, waits 30 seconds and then outputs the answer.
 
         Also informs of the percentages and votes of each option
         """
@@ -96,13 +96,13 @@ class EggheadQuiz(commands.Cog):
 
     @staticmethod
     async def already_reacted(message, user):
-        """Returns whether a given user has reacted more than once to a given message"""
+        """Returns whether a given user has reacted more than once to a given message."""
         users = [u.id for reaction in [await r.users().flatten() for r in message.reactions] for u in reaction]
         return users.count(user.id) > 1  # Old reaction plus new reaction
 
     @commands.Cog.listener()
     async def on_reaction_add(self, reaction, user):
-        """Listener to listen specifically for reactions of quiz messages"""
+        """Listener to listen specifically for reactions of quiz messages."""
         if user.bot:
             return
         if reaction.message.id not in self.quiz_messages:

--- a/bot/seasons/easter/traditions.py
+++ b/bot/seasons/easter/traditions.py
@@ -19,7 +19,7 @@ class Traditions(commands.Cog):
 
     @commands.command(aliases=('eastercustoms',))
     async def easter_tradition(self, ctx):
-        """Responds with a random tradition or custom"""
+        """Responds with a random tradition or custom."""
         random_country = random.choice(list(traditions))
 
         await ctx.send(f"{random_country}:\n{traditions[random_country]}")

--- a/bot/seasons/evergreen/8bitify.py
+++ b/bot/seasons/evergreen/8bitify.py
@@ -13,17 +13,17 @@ class EightBitify(commands.Cog):
 
     @staticmethod
     def pixelate(image: Image) -> Image:
-        """Takes an image and pixelates it"""
+        """Takes an image and pixelates it."""
         return image.resize((32, 32)).resize((1024, 1024))
 
     @staticmethod
     def quantize(image: Image) -> Image:
-        """Reduces colour palette to 256 colours"""
+        """Reduces colour palette to 256 colours."""
         return image.quantize(colors=32)
 
     @commands.command(name="8bitify")
     async def eightbit_command(self, ctx: commands.Context) -> None:
-        """Pixelates your avatar and changes the palette to an 8bit one"""
+        """Pixelates your avatar and changes the palette to an 8bit one."""
         async with ctx.typing():
             image_bytes = await ctx.author.avatar_url.read()
             avatar = Image.open(BytesIO(image_bytes))

--- a/bot/seasons/evergreen/minesweeper.py
+++ b/bot/seasons/evergreen/minesweeper.py
@@ -33,7 +33,7 @@ class CoordinateConverter(commands.Converter):
     """Converter for Coordinates."""
 
     async def convert(self, ctx, coordinate: str) -> typing.Tuple[int, int]:
-        """Take in a coordinate string and turn it into x, y"""
+        """Take in a coordinate string and turn it into an (x, y) tuple."""
         if not 2 <= len(coordinate) <= 3:
             raise commands.BadArgument('Invalid co-ordinate provided')
 
@@ -81,7 +81,7 @@ class Minesweeper(commands.Cog):
 
     @commands.group(name='minesweeper', aliases=('ms',), invoke_without_command=True)
     async def minesweeper_group(self, ctx: commands.Context):
-        """Commands for Playing Minesweeper"""
+        """Commands for Playing Minesweeper."""
         await ctx.send_help(ctx.command)
 
     @staticmethod
@@ -175,7 +175,7 @@ class Minesweeper(commands.Cog):
     @commands.dm_only()
     @minesweeper_group.command(name="flag")
     async def flag_command(self, ctx: commands.Context, *coordinates: CoordinateConverter) -> None:
-        """Place multiple flags on the board"""
+        """Place multiple flags on the board."""
         board: GameBoard = self.games[ctx.author.id].revealed
         for x, y in coordinates:
             if board[y][x] == "hidden":
@@ -185,14 +185,14 @@ class Minesweeper(commands.Cog):
 
     @staticmethod
     def reveal_bombs(revealed: GameBoard, board: GameBoard) -> None:
-        """Reveals all the bombs"""
+        """Reveals all the bombs."""
         for y, row in enumerate(board):
             for x, cell in enumerate(row):
                 if cell == "bomb":
                     revealed[y][x] = cell
 
     async def lost(self, ctx: commands.Context) -> None:
-        """The player lost the game"""
+        """The player lost the game."""
         game = self.games[ctx.author.id]
         self.reveal_bombs(game.revealed, game.board)
         await ctx.author.send(":fire: You lost! :fire:")
@@ -200,7 +200,7 @@ class Minesweeper(commands.Cog):
             await game.chat_msg.channel.send(f":fire: {ctx.author.mention} just lost Minesweeper! :fire:")
 
     async def won(self, ctx: commands.Context) -> None:
-        """The player won the game"""
+        """The player won the game."""
         game = self.games[ctx.author.id]
         await ctx.author.send(":tada: You won! :tada:")
         if game.activated_on_server:
@@ -216,7 +216,7 @@ class Minesweeper(commands.Cog):
                 self.reveal_zeros(revealed, board, x_, y_)
 
     async def check_if_won(self, ctx, revealed: GameBoard, board: GameBoard) -> bool:
-        """Checks if a player has won"""
+        """Checks if a player has won."""
         if any(
             revealed[y][x] in ["hidden", "flag"] and board[y][x] != "bomb"
             for x in range(10)
@@ -252,7 +252,7 @@ class Minesweeper(commands.Cog):
     @commands.dm_only()
     @minesweeper_group.command(name="reveal")
     async def reveal_command(self, ctx: commands.Context, *coordinates: CoordinateConverter) -> None:
-        """Reveal multiple cells"""
+        """Reveal multiple cells."""
         game = self.games[ctx.author.id]
         revealed: GameBoard = game.revealed
         board: GameBoard = game.board
@@ -268,7 +268,7 @@ class Minesweeper(commands.Cog):
 
     @minesweeper_group.command(name="end")
     async def end_command(self, ctx: commands.Context):
-        """End your current game"""
+        """End your current game."""
         game = self.games[ctx.author.id]
         game.revealed = game.board
         await self.update_boards(ctx)

--- a/bot/seasons/evergreen/showprojects.py
+++ b/bot/seasons/evergreen/showprojects.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 
 class ShowProjects(commands.Cog):
-    """Cog that reacts to posts in the #show-your-projects"""
+    """Cog that reacts to posts in the #show-your-projects."""
 
     def __init__(self, bot):
         self.bot = bot
@@ -16,7 +16,7 @@ class ShowProjects(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
-        """Adds reactions to posts in #show-your-projects"""
+        """Adds reactions to posts in #show-your-projects."""
         reactions = ["\U0001f44d", "\U00002764", "\U0001f440", "\U0001f389", "\U0001f680", "\U00002b50", "\U0001f6a9"]
         if (message.channel.id == Channels.show_your_projects
                 and message.author.bot is False
@@ -28,6 +28,6 @@ class ShowProjects(commands.Cog):
 
 
 def setup(bot):
-    """Show Projects Reaction Cog"""
+    """Show Projects Reaction Cog."""
     bot.add_cog(ShowProjects(bot))
     log.info("ShowProjects cog loaded")

--- a/bot/seasons/evergreen/snakes/utils.py
+++ b/bot/seasons/evergreen/snakes/utils.py
@@ -436,7 +436,7 @@ class SnakeAndLaddersGame:
                 if reaction.emoji == JOIN_EMOJI:
                     await self.player_join(user)
                 elif reaction.emoji == CANCEL_EMOJI:
-                    if user == self.author or not self._mod_in_game_check(user):
+                    if user == self.author or all((self._is_moderator(user), user not in self.players)):
                         # Allow game author or non-playing moderation staff to cancel a waiting game
                         await self.cancel_game()
                         return
@@ -705,10 +705,6 @@ class SnakeAndLaddersGame:
         if is_reversed:
             x_level = 9 - x_level
         return x_level, y_level
-
-    def _mod_in_game_check(self, user: Member) -> bool:
-        """Return True if user is a Moderator and playing the currently running game."""
-        return all((self._is_moderator(user), user in self.players))
 
     @staticmethod
     def _is_moderator(user: Member) -> bool:

--- a/bot/seasons/evergreen/snakes/utils.py
+++ b/bot/seasons/evergreen/snakes/utils.py
@@ -494,7 +494,7 @@ class SnakeAndLaddersGame:
         """
         Handle players leaving the game.
 
-        Leaving is prevented if the user wesn't part of the game.
+        Leaving is prevented if the user wasn't part of the game.
 
         If the number of players reaches 0, the game is terminated. In this case, a sentinel boolean
         is returned True to prevent a game from continuing after it's destroyed.
@@ -616,7 +616,7 @@ class SnakeAndLaddersGame:
                 if reaction.emoji == ROLL_EMOJI:
                     await self.player_roll(user)
                 elif reaction.emoji == CANCEL_EMOJI:
-                    if self._is_moderator(user) and not self._mod_in_game_check(user):
+                    if self._is_moderator(user) and user not in self.players:
                         # Only allow non-playing moderation staff to cancel a running game
                         await self.cancel_game()
                         return
@@ -713,4 +713,4 @@ class SnakeAndLaddersGame:
     @staticmethod
     def _is_moderator(user: Member) -> bool:
         """Return True if the user is a Moderator."""
-        return Roles.moderator in [role.id for role in user.roles]
+        return any(Roles.moderator == role.id for role in user.roles)

--- a/bot/seasons/evergreen/snakes/utils.py
+++ b/bot/seasons/evergreen/snakes/utils.py
@@ -436,7 +436,7 @@ class SnakeAndLaddersGame:
                 if reaction.emoji == JOIN_EMOJI:
                     await self.player_join(user)
                 elif reaction.emoji == CANCEL_EMOJI:
-                    if user == self.author or all((self._is_moderator(user), user not in self.players)):
+                    if user == self.author or (self._is_moderator(user) and user not in self.players):
                         # Allow game author or non-playing moderation staff to cancel a waiting game
                         await self.cancel_game()
                         return

--- a/bot/seasons/evergreen/snakes/utils.py
+++ b/bot/seasons/evergreen/snakes/utils.py
@@ -13,6 +13,8 @@ from PIL.ImageDraw import ImageDraw
 from discord import File, Member, Reaction
 from discord.ext.commands import Context
 
+from bot.constants import Roles
+
 SNAKE_RESOURCES = Path("bot/resources/snakes").absolute()
 
 h1 = r'''```
@@ -412,7 +414,6 @@ class SnakeAndLaddersGame:
             "**Snakes and Ladders**: A new game is about to start!",
             file=File(
                 str(SNAKE_RESOURCES / "snakes_and_ladders" / "banner.jpg"),
-                # os.path.join("bot", "resources", "snakes", "snakes_and_ladders", "banner.jpg"),
                 filename='Snakes and Ladders.jpg'
             )
         )
@@ -435,8 +436,9 @@ class SnakeAndLaddersGame:
                 if reaction.emoji == JOIN_EMOJI:
                     await self.player_join(user)
                 elif reaction.emoji == CANCEL_EMOJI:
-                    if self.ctx.author == user:
-                        await self.cancel_game(user)
+                    if user == self.author or not self._mod_in_game_check(user):
+                        # Allow game author or non-playing moderation staff to cancel a waiting game
+                        await self.cancel_game()
                         return
                     else:
                         await self.player_leave(user)
@@ -451,7 +453,7 @@ class SnakeAndLaddersGame:
 
             except asyncio.TimeoutError:
                 log.debug("Snakes and Ladders timed out waiting for a reaction")
-                self.cancel_game(self.author)
+                await self.cancel_game()
                 return  # We're done, no reactions for the last 5 minutes
 
     async def _add_player(self, user: Member):
@@ -488,20 +490,16 @@ class SnakeAndLaddersGame:
             delete_after=10
         )
 
-    async def player_leave(self, user: Member):
+    async def player_leave(self, user: Member) -> bool:
         """
         Handle players leaving the game.
 
-        Leaving is prevented if the user initiated the game or if they weren't part of it in the
-        first place.
+        Leaving is prevented if the user wesn't part of the game.
+
+        If the number of players reaches 0, the game is terminated. In this case, a sentinel boolean
+        is returned True to prevent a game from continuing after it's destroyed.
         """
-        if user == self.author:
-            await self.channel.send(
-                user.mention + " You are the author, and cannot leave the game. Execute "
-                "`sal cancel` to cancel the game.",
-                delete_after=10
-            )
-            return
+        is_surrendered = False  # Sentinel value to assist with stopping a surrendered game
         for p in self.players:
             if user == p:
                 self.players.remove(p)
@@ -512,17 +510,18 @@ class SnakeAndLaddersGame:
                     delete_after=10
                 )
 
-                if self.state != 'waiting' and len(self.players) == 1:
+                if self.state != 'waiting' and len(self.players) == 0:
                     await self.channel.send("**Snakes and Ladders**: The game has been surrendered!")
+                    is_surrendered = True
                     self._destruct()
-                return
-        await self.channel.send(user.mention + " You are not in the match.", delete_after=10)
 
-    async def cancel_game(self, user: Member):
-        """Allow the game author to cancel the running game."""
-        if not user == self.author:
-            await self.channel.send(user.mention + " Only the author of the game can cancel it.", delete_after=10)
-            return
+                return is_surrendered
+        else:
+            await self.channel.send(user.mention + " You are not in the match.", delete_after=10)
+            return is_surrendered
+
+    async def cancel_game(self):
+        """Cancel the running game."""
         await self.channel.send("**Snakes and Ladders**: Game has been canceled.")
         self._destruct()
 
@@ -530,21 +529,16 @@ class SnakeAndLaddersGame:
         """
         Allow the game author to begin the game.
 
-        The game cannot be started if there aren't enough players joined or if the game is in a
-        waiting state.
+        The game cannot be started if the game is in a waiting state.
         """
         if not user == self.author:
             await self.channel.send(user.mention + " Only the author of the game can start it.", delete_after=10)
             return
-        if len(self.players) < 1:
-            await self.channel.send(
-                user.mention + " A minimum of 2 players is required to start the game.",
-                delete_after=10
-            )
-            return
+
         if not self.state == 'waiting':
             await self.channel.send(user.mention + " The game cannot be started at this time.", delete_after=10)
             return
+
         self.state = 'starting'
         player_list = ', '.join(user.mention for user in self.players)
         await self.channel.send("**Snakes and Ladders**: The game is starting!\nPlayers: " + player_list)
@@ -565,8 +559,6 @@ class SnakeAndLaddersGame:
         self.state = 'roll'
         for user in self.players:
             self.round_has_rolled[user.id] = False
-        # board_img = Image.open(os.path.join(
-        #     "bot", "resources", "snakes", "snakes_and_ladders", "board.jpg"))
         board_img = Image.open(str(SNAKE_RESOURCES / "snakes_and_ladders" / "board.jpg"))
         player_row_size = math.ceil(MAX_PLAYERS / 2)
 
@@ -612,6 +604,7 @@ class SnakeAndLaddersGame:
         for emoji in GAME_SCREEN_EMOJI:
             await self.positions.add_reaction(emoji)
 
+        is_surrendered = False
         while True:
             try:
                 reaction, user = await self.ctx.bot.wait_for(
@@ -623,11 +616,12 @@ class SnakeAndLaddersGame:
                 if reaction.emoji == ROLL_EMOJI:
                     await self.player_roll(user)
                 elif reaction.emoji == CANCEL_EMOJI:
-                    if self.ctx.author == user:
-                        await self.cancel_game(user)
+                    if self._is_moderator(user) and not self._mod_in_game_check(user):
+                        # Only allow non-playing moderation staff to cancel a running game
+                        await self.cancel_game()
                         return
                     else:
-                        await self.player_leave(user)
+                        is_surrendered = await self.player_leave(user)
 
                 await self.positions.remove_reaction(reaction.emoji, user)
 
@@ -636,11 +630,14 @@ class SnakeAndLaddersGame:
 
             except asyncio.TimeoutError:
                 log.debug("Snakes and Ladders timed out waiting for a reaction")
-                await self.cancel_game(self.author)
+                await self.cancel_game()
                 return  # We're done, no reactions for the last 5 minutes
 
         # Round completed
-        await self._complete_round()
+        # Check to see if the game was surrendered before completing the round, without this
+        # sentinel, the game object would be deleted but the next round still posted into purgatory
+        if not is_surrendered:
+            await self._complete_round()
 
     async def player_roll(self, user: Member):
         """Handle the player's roll."""
@@ -708,3 +705,12 @@ class SnakeAndLaddersGame:
         if is_reversed:
             x_level = 9 - x_level
         return x_level, y_level
+
+    def _mod_in_game_check(self, user: Member) -> bool:
+        """Return True if user is a Moderator and playing the currently running game."""
+        return all((self._is_moderator(user), user in self.players))
+
+    @staticmethod
+    def _is_moderator(user: Member) -> bool:
+        """Return True if the user is a Moderator."""
+        return Roles.moderator in [role.id for role in user.roles]

--- a/bot/seasons/evergreen/speedrun.py
+++ b/bot/seasons/evergreen/speedrun.py
@@ -23,6 +23,6 @@ class Speedrun(commands.Cog):
 
 
 def setup(bot):
-    """Load the Speedrun cog"""
+    """Load the Speedrun cog."""
     bot.add_cog(Speedrun(bot))
     log.info("Speedrun cog loaded")

--- a/bot/seasons/halloween/candy_collection.py
+++ b/bot/seasons/halloween/candy_collection.py
@@ -121,15 +121,16 @@ class CandyCollection(commands.Cog):
     async def ten_recent_msg(self):
         """Get the last 10 messages sent in the channel."""
         ten_recent = []
-        recent_msg = max(message.id for message
-                         in self.bot._connection._messages
-                         if message.channel.id == Channels.seasonalbot_chat)
+        recent_msg_id = max(
+            message.id for message in self.bot._connection._messages
+            if message.channel.id == Channels.seasonalbot_chat
+        )
 
         channel = await self.hacktober_channel()
-        ten_recent.append(recent_msg.id)
+        ten_recent.append(recent_msg_id)
 
         for i in range(9):
-            o = discord.Object(id=recent_msg.id + i)
+            o = discord.Object(id=recent_msg_id + i)
             msg = await next(channel.history(limit=1, before=o))
             ten_recent.append(msg.id)
 

--- a/bot/seasons/halloween/monstersurvey.py
+++ b/bot/seasons/halloween/monstersurvey.py
@@ -60,7 +60,7 @@ class MonsterSurvey(Cog):
 
     @commands.group(
         name='monster',
-        aliases=('ms',)
+        aliases=('mon',)
     )
     async def monster_group(self, ctx: Context):
         """The base voting command. If nothing is called, then it will return an embed."""

--- a/bot/seasons/halloween/spookyrating.py
+++ b/bot/seasons/halloween/spookyrating.py
@@ -17,7 +17,7 @@ with Path("bot/resources/halloween/spooky_rating.json").open() as file:
 
 
 class SpookyRating(commands.Cog):
-    """A cog for calculating one's spooky rating"""
+    """A cog for calculating one's spooky rating."""
 
     def __init__(self, bot):
         self.bot = bot

--- a/bot/utils/__init__.py
+++ b/bot/utils/__init__.py
@@ -110,7 +110,7 @@ def replace_many(
     regex = re.compile(pattern, re.I if ignore_case else 0)
 
     def _repl(match):
-        """Returns replacement depending on `ignore_case` and `match_case`"""
+        """Returns replacement depending on `ignore_case` and `match_case`."""
         word = match.group(0)
         replacement = replacements[word.lower() if ignore_case else word]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 [flake8]
 max-line-length=120
 application_import_names=bot
+docstring-convention=all
 ignore=
     P102,B311,W503,E226,S311,
     # Missing Docstrings
-    D100,D104,D107,
+    D100,D104,D105,D107,
     # Docstring Whitespace
     D203,D212,D214,D215,
     # Docstring Quotes
     D301,D302,
     # Docstring Content
-    D400,D401,D402,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414
+    D400,D401,D402,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414,D416,D417
 exclude=
     __pycache__,.cache,
     venv,.venv,


### PR DESCRIPTION
This PR addresses some issues in 2 cogs:

**Hacktoberfest**
Some minor cleanup to get the cog ready for the upcoming event:
* Fix command typo in account linking helper message
* Remove hardcoded values for event year & number of PRs before one gets a shirt, adjust related functionality
* Some type hinting kaizen in advance of #248

**Snakes**
The Snakes and Ladders command has been updated:
* The game can now be played solo
* Add missing `await` to the reaction timeout while waiting for the game to start, preventing the game from being cancelled after the timeout is reached & freeing the channel for another game
* Update cancellation logic as follows (per #253):
  * Game has timed out
  * There are no players left in the game
  * Non-player Moderation staff can cancel the game at any time
  * After a game has started, the initiator will no longer cancel the game if they leave; they can still cancel the game before it has started
* Fix issue with the game continuing after all players have left
  * This was caused by a bug in the round's logic flow. Because the game surrender logic is contained in the reaction block for the round, the round completion coroutine is still invoked after the game is surrendered so a new round is posted to the channel after the game object is deleted.

The alias for the Monster Survey cog has also been adjusted to deconflict with the alias for the Minesweeper cog.

This also adds a fix for our improperly configured flake8-docstring linter (see: https://github.com/python-discord/organisation/issues/131)

Closes: #252 