### PR TITLE
Update flake8-annotation pin & relint

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ pytz = "~=2019.2"
 
 [dev-packages]
 flake8 = "~=3.7"
-flake8-annotations = "~=1.0"
+flake8-annotations = "~=1.1"
 flake8-bugbear = "~=19.8"
 flake8-docstrings = "~=1.4"
 flake8-import-order = "~=0.18"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8861de068d14f2c48bebdc2691ab62753c502ffb20735aa7b037b154f9f84a9c"
+            "sha256": "da19ab2567a55706054eae245eb95a2b6f861836a47ef40641b0c6976b509c65"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -53,11 +53,11 @@
         },
         "arrow": {
             "hashes": [
-                "sha256:704f5403299fe092c69479e0a2516a434003e82d37439a9e47c31285faf3947b",
-                "sha256:9b92a8e151e168b742a36b622deadf860d1686af8c5bbe46eca8da04b10fe92f"
+                "sha256:10257c5daba1a88db34afa284823382f4963feca7733b9107956bed041aff24f",
+                "sha256:c2325911fcd79972cf493cfd957072f9644af8ad25456201ae1ede3316576eb4"
             ],
             "index": "pypi",
-            "version": "==0.15.0"
+            "version": "==0.15.2"
         },
         "async-timeout": {
             "hashes": [
@@ -230,7 +230,6 @@
         },
         "pycparser": {
             "hashes": [
-                "sha256:83870b0dff6e9c1b1f721ee062f2e198c1ce7f107220020bf4de788dca009944",
                 "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
             ],
             "version": "==2.19"
@@ -259,10 +258,10 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:8662843366b8d8779dec4e2f921bebec9afd856a5ff2e82cd419acc5054a1a92",
-                "sha256:a5a6166b4767725fd52ae55fee8c8b6137d9a51e9f1edea461a062a759160118"
+                "sha256:605f89ad5fdbfefe30cdc293303665eff2d188865d4dbe4eb510bba1edfbfce3",
+                "sha256:b91d676b330a0ebd5b21719cb6e9b57c57d433671f65b9c28dd3461d9a1ed0b6"
             ],
-            "version": "==1.9.3"
+            "version": "==1.9.4"
         },
         "websockets": {
             "hashes": [
@@ -346,11 +345,11 @@
         },
         "flake8-annotations": {
             "hashes": [
-                "sha256:1309f2bc9853a2d77d578b089d331b0b832b40c97932641e136e1b49d3650c82",
-                "sha256:3ecdd27054c3eed6484139025698465e3c9f4e68dbd5043d0204fcb2550ee27b"
+                "sha256:6ac7ca1e706307686b60af8043ff1db31dc2cfc1233c8210d67a3d9b8f364736",
+                "sha256:b51131007000d67217608fa028a35ff80aa400b474e5972f1f99c2cf9d26bd2e"
             ],
             "index": "pypi",
-            "version": "==1.0.0"
+            "version": "==1.1.0"
         },
         "flake8-bugbear": {
             "hashes": [
@@ -408,10 +407,10 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:9ff1b1c5a354142de080b8a4e9803e5d0d59283c93aed808617c787d16768375",
-                "sha256:b7143592e374e50584564794fcb8aaf00a23025f9db866627f89a21491847a8d"
+                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
+                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
             ],
-            "version": "==0.20"
+            "version": "==0.23"
         },
         "mccabe": {
             "hashes": [
@@ -499,6 +498,26 @@
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "version": "==0.10.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e",
+                "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e",
+                "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0",
+                "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c",
+                "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631",
+                "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4",
+                "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34",
+                "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b",
+                "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a",
+                "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233",
+                "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1",
+                "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36",
+                "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d",
+                "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
+                "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
+            ],
+            "version": "==1.4.0"
         },
         "virtualenv": {
             "hashes": [

--- a/bot/seasons/easter/avatar_easterifier.py
+++ b/bot/seasons/easter/avatar_easterifier.py
@@ -56,7 +56,7 @@ class AvatarEasterifier(commands.Cog):
         Colours are split by spaces, unless you wrap the colour name in double quotes.
         Discord colour names, HTML colour names, XKCD colour names and hex values are accepted.
         """
-        async def send(*args, **kwargs):
+        async def send(*args, **kwargs) -> str:
             """
             This replaces the original ctx.send.
 

--- a/bot/seasons/evergreen/fun.py
+++ b/bot/seasons/evergreen/fun.py
@@ -72,7 +72,7 @@ class Fun(Cog):
 
         Also accepts a valid discord Message ID or link.
         """
-        def conversion_func(text):
+        def conversion_func(text: str) -> str:
             """Randomly converts the casing of a given string."""
             return "".join(
                 char.upper() if round(random.random()) else char.lower() for char in text

--- a/bot/seasons/season.py
+++ b/bot/seasons/season.py
@@ -303,7 +303,7 @@ class SeasonBase:
                 cogs.append(cog_name)
 
         if cogs:
-            def cog_name(cog):
+            def cog_name(cog: commands.Cog) -> str:
                 return type(cog).__name__
 
             cog_info = []

--- a/bot/seasons/valentines/lovecalculator.py
+++ b/bot/seasons/valentines/lovecalculator.py
@@ -53,7 +53,7 @@ class LoveCalculator(Cog):
             staff = ctx.guild.get_role(Roles.helpers).members
             whom = random.choice(staff)
 
-        def normalize(arg):
+        def normalize(arg: Union[Member, str]) -> str:
             if isinstance(arg, Member):
                 # If we are given a member, return name#discrim without any extra changes
                 arg = str(arg)


### PR DESCRIPTION
flake8-annotations v1.1 was recently released, which includes a fix for incorrect parsing of nested functions.

This PR updates the dependency pinning & fixes the annotations that were missed previously.