### PR TITLE
Disable halloween announcement and add hacktober icon.

### DIFF
--- a/bot/seasons/halloween/__init__.py
+++ b/bot/seasons/halloween/__init__.py
@@ -3,16 +3,22 @@ from bot.seasons import SeasonBase
 
 
 class Halloween(SeasonBase):
-    """Halloween Seasonal event attributes."""
+    """
+    Halloween Seasonal event attributes.
+
+    Announcement for this cog temporarily disabled, since we're doing a custom
+    Hacktoberfest announcement. If you're enabling the announcement again,
+    make sure to update this docstring accordingly.
+    """
 
     name = "halloween"
-    bot_name = "Spookybot"
+    bot_name = "NeonBot"
     greeting = "Happy Halloween!"
 
     start_date = "01/10"
     end_date = "01/11"
 
-    colour = Colours.orange
+    colour = Colours.pink
     icon = (
-        "/logos/logo_seasonal/halloween/spooky.png",
+        "/logos/logo_seasonal/hacktober/hacktoberfest.png",
     )

--- a/bot/seasons/season.py
+++ b/bot/seasons/season.py
@@ -271,7 +271,7 @@ class SeasonBase:
         It will skip the announcement if the current active season is the "evergreen" default season.
         """
         # Don't actually announce if reverting to normal season
-        if self.name in ("evergreen", "wildcard"):
+        if self.name in ("evergreen", "wildcard", "halloween"):
             log.debug(f"Season Changed: {self.name}")
             return
 


### PR DESCRIPTION
The Halloween season was currently configured to run with spooky icons and to announce a terrible, contentless announcement.

This has been disabled and the neon hacktoberfest icon has been placed in its stead.

This has to be merged _today_, so please make post-haste, good Sirs and Ladies.