### PR TITLE
Hacktober date range and channel whitelist fixes

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -52,6 +52,7 @@ class Channels(NamedTuple):
     python_discussion = 267624335836053506
     show_your_projects = int(environ.get("CHANNEL_SHOW_YOUR_PROJECTS", 303934982764625920))
     show_your_projects_discussion = 360148304664723466
+    hacktoberfest_2019 = 628184417646411776
 
 
 class Client(NamedTuple):
@@ -125,7 +126,7 @@ STAFF_ROLES = Roles.helpers, Roles.moderator, Roles.admin, Roles.owner
 WHITELISTED_CHANNELS = (
     Channels.bot, Channels.seasonalbot_commands,
     Channels.off_topic_0, Channels.off_topic_1, Channels.off_topic_2,
-    Channels.devtest,
+    Channels.devtest, Channels.hacktoberfest_2019,
 )
 
 # Bot replies

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -126,7 +126,7 @@ STAFF_ROLES = Roles.helpers, Roles.moderator, Roles.admin, Roles.owner
 WHITELISTED_CHANNELS = (
     Channels.bot, Channels.seasonalbot_commands,
     Channels.off_topic_0, Channels.off_topic_1, Channels.off_topic_2,
-    Channels.devtest, Channels.hacktoberfest_2019,
+    Channels.devtest,
 )
 
 # Bot replies

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -64,9 +64,11 @@ def without_role(*role_ids: int) -> bool:
 
 
 def in_channel_check(*channels: int, bypass_roles: typing.Container[int] = None) -> typing.Callable[[Context], bool]:
-    """Checks that the message is in a whitelisted channel or optionally has a bypass role.
+    """
+    Checks that the message is in a whitelisted channel or optionally has a bypass role.
 
-       If `in_channel_override` is present, check if it contains channels and use them in place of global whitelist"""
+    If `in_channel_override` is present, check if it contains channels and use them in place of global whitelist
+    """
     def predicate(ctx: Context) -> bool:
         if not ctx.guild:
             log.debug(f"{ctx.author} tried to use the '{ctx.command.name}' command from a DM.")

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -129,7 +129,7 @@ def override_in_channel(channels: typing.Tuple[int] = None) -> typing.Callable:
 
     This decorator has to go before (below) below the `command` decorator.
     """
-    def inner(func: typing.Callable):
+    def inner(func: typing.Callable) -> typing.Callable:
         func.in_channel_override = channels
         return func
 

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -67,7 +67,8 @@ def in_channel_check(*channels: int, bypass_roles: typing.Container[int] = None)
     """
     Checks that the message is in a whitelisted channel or optionally has a bypass role.
 
-    If `in_channel_override` is present, check if it contains channels and use them in place of global whitelist
+    If `in_channel_override` is present, check if it contains channels
+    and use them in place of the global whitelist.
     """
     def predicate(ctx: Context) -> bool:
         if not ctx.guild:

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -95,6 +95,11 @@ def in_channel_check(*channels: int, bypass_roles: typing.Container[int] = None)
                         f"and the command was used in an overridden whitelisted channel."
                     )
                     return True
+
+                log.debug(
+                    f"{ctx.author} tried to call the '{ctx.command.name}' command. "
+                    f"The overridden in_channel check failed."
+                )
                 channels_str = ', '.join(f"<#{c_id}>" for c_id in override)
                 raise InChannelCheckFailure(
                     f"Sorry, but you may only use this command within {channels_str}."

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -126,7 +126,7 @@ class AdventOfCode(commands.Cog):
         self.status_task = asyncio.ensure_future(self.bot.loop.create_task(status_coro))
 
     @commands.group(name="adventofcode", aliases=("aoc",), invoke_without_command=True)
-    @override_in_channel
+    @override_in_channel()
     async def adventofcode_group(self, ctx: commands.Context) -> None:
         """All of the Advent of Code commands."""
         await ctx.send_help(ctx.command)

--- a/bot/seasons/evergreen/issues.py
+++ b/bot/seasons/evergreen/issues.py
@@ -16,7 +16,7 @@ class Issues(commands.Cog):
         self.bot = bot
 
     @commands.command(aliases=("issues",))
-    @override_in_channel
+    @override_in_channel()
     async def issue(
         self, ctx: commands.Context, number: int, repository: str = "seasonalbot", user: str = "python-discord"
     ) -> None:

--- a/bot/seasons/halloween/hacktoberstats.py
+++ b/bot/seasons/halloween/hacktoberstats.py
@@ -10,7 +10,10 @@ import aiohttp
 import discord
 from discord.ext import commands
 
+from bot.constants import Channels, STAFF_ROLES, WHITELISTED_CHANNELS
+from bot.decorators import in_channel_check
 from bot.utils.persist import make_persistent
+
 
 log = logging.getLogger(__name__)
 
@@ -26,6 +29,7 @@ class HacktoberStats(commands.Cog):
         self.link_json = make_persistent(Path("bot", "resources", "halloween", "github_links.json"))
         self.linked_accounts = self.load_linked_users()
 
+    @commands.check(in_channel_check(*(*WHITELISTED_CHANNELS, Channels.hacktoberfest_2019), bypass_roles=STAFF_ROLES))
     @commands.group(name="hacktoberstats", aliases=("hackstats",), invoke_without_command=True)
     async def hacktoberstats_group(self, ctx: commands.Context, github_username: str = None) -> None:
         """

--- a/bot/seasons/halloween/hacktoberstats.py
+++ b/bot/seasons/halloween/hacktoberstats.py
@@ -220,7 +220,7 @@ class HacktoberStats(commands.Cog):
         not_label = "invalid"
         action_type = "pr"
         is_query = f"public+author:{github_username}"
-        date_range = f"{CURRENT_YEAR}-10-01..{CURRENT_YEAR}-10-31"
+        date_range = f"{CURRENT_YEAR}-10-01T00:00:00%2B14:00..{CURRENT_YEAR}-10-31T00:00:00-11:00"
         per_page = "300"
         query_url = (
             f"{base_url}"

--- a/bot/seasons/halloween/hacktoberstats.py
+++ b/bot/seasons/halloween/hacktoberstats.py
@@ -10,8 +10,8 @@ import aiohttp
 import discord
 from discord.ext import commands
 
-from bot.constants import Channels, STAFF_ROLES, WHITELISTED_CHANNELS
-from bot.decorators import in_channel_check
+from bot.constants import Channels, WHITELISTED_CHANNELS
+from bot.decorators import override_in_channel
 from bot.utils.persist import make_persistent
 
 
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 
 CURRENT_YEAR = datetime.now().year  # Used to construct GH API query
 PRS_FOR_SHIRT = 4  # Minimum number of PRs before a shirt is awarded
+HACKTOBER_WHITELIST = WHITELISTED_CHANNELS + (Channels.hacktoberfest_2019,)
 
 
 class HacktoberStats(commands.Cog):
@@ -29,8 +30,8 @@ class HacktoberStats(commands.Cog):
         self.link_json = make_persistent(Path("bot", "resources", "halloween", "github_links.json"))
         self.linked_accounts = self.load_linked_users()
 
-    @commands.check(in_channel_check(*(*WHITELISTED_CHANNELS, Channels.hacktoberfest_2019), bypass_roles=STAFF_ROLES))
     @commands.group(name="hacktoberstats", aliases=("hackstats",), invoke_without_command=True)
+    @override_in_channel(HACKTOBER_WHITELIST)
     async def hacktoberstats_group(self, ctx: commands.Context, github_username: str = None) -> None:
         """
         Display an embed for a user's Hacktoberfest contributions.

--- a/bot/seasons/halloween/hacktoberstats.py
+++ b/bot/seasons/halloween/hacktoberstats.py
@@ -235,7 +235,7 @@ class HacktoberStats(commands.Cog):
             f"&per_page={per_page}"
         )
 
-        headers = {"user-agent": "Discord Python Hactoberbot"}
+        headers = {"user-agent": "Discord Python Hacktoberbot"}
         async with aiohttp.ClientSession() as session:
             async with session.get(query_url, headers=headers) as resp:
                 jsonresp = await resp.json()


### PR DESCRIPTION
This PR extends the date ranges of the search query to cover the beginning of October in the first timezone and the end in the last timezone;
Adds the 2019 Hacktoberfest channel to the white-list for bot commands.

Closes #282 #283 