### PR TITLE
Put role bypass check above channel override check

### DIFF
--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -81,6 +81,13 @@ def in_channel_check(*channels: int, bypass_roles: typing.Container[int] = None)
             )
             return True
 
+        if bypass_roles and any(r.id in bypass_roles for r in ctx.author.roles):
+            log.debug(
+                f"{ctx.author} called the '{ctx.command.name}' command and "
+                f"had a role to bypass the in_channel check."
+            )
+            return True
+
         if hasattr(ctx.command.callback, "in_channel_override"):
             override = ctx.command.callback.in_channel_override
             if override is None:
@@ -105,13 +112,6 @@ def in_channel_check(*channels: int, bypass_roles: typing.Container[int] = None)
                 raise InChannelCheckFailure(
                     f"Sorry, but you may only use this command within {channels_str}."
                 )
-
-        if bypass_roles and any(r.id in bypass_roles for r in ctx.author.roles):
-            log.debug(
-                f"{ctx.author} called the '{ctx.command.name}' command and "
-                f"had a role to bypass the in_channel check."
-            )
-            return True
 
         log.debug(
             f"{ctx.author} tried to call the '{ctx.command.name}' command. "

--- a/bot/seasons/halloween/hacktoberstats.py
+++ b/bot/seasons/halloween/hacktoberstats.py
@@ -225,7 +225,7 @@ class HacktoberStats(commands.Cog):
         not_label = "invalid"
         action_type = "pr"
         is_query = f"public+author:{github_username}"
-        date_range = f"{CURRENT_YEAR}-10-01T00:00:00%2B14:00..{CURRENT_YEAR}-10-31T00:00:00-11:00"
+        date_range = f"{CURRENT_YEAR}-10-01T00:00:00%2B14:00..{CURRENT_YEAR}-10-31T23:59:59-11:00"
         per_page = "300"
         query_url = (
             f"{base_url}"


### PR DESCRIPTION
In the rewritten in_channel_check, if the command override was used, role bypass wouldn't take effect because the function would exit before it. This PR puts the bypass check above the override check to make sure the roles will bypass it.