### PR TITLE
Ignore Draft PRs in .hackstats

### DIFF
--- a/bot/seasons/halloween/hacktoberstats.py
+++ b/bot/seasons/halloween/hacktoberstats.py
@@ -238,8 +238,9 @@ class HacktoberStats(commands.Cog):
             f"&per_page={per_page}"
         )
 
+        headers = {"user-agent": "Discord Python Hacktoberbot"}
         async with aiohttp.ClientSession() as session:
-            async with session.get(query_url) as resp:
+            async with session.get(query_url, headers=headers) as resp:
                 jsonresp = await resp.json()
 
         if "message" in jsonresp.keys():


### PR DESCRIPTION
**Closes #304**

Draft Pull Requests still count as valid in the current `.hackstats` command but do not for the official DigitalOcean event.

This is mitigated by checking for the `draft` field and ignoring PRs where it is `True`.