### PR TITLE
Add two new icons to icon constant

### DIFF
--- a/bot/seasons/evergreen/__init__.py
+++ b/bot/seasons/evergreen/__init__.py
@@ -10,4 +10,6 @@ class Evergreen(SeasonBase):
         "/logos/logo_animated/spinner/spinner.gif",
         "/logos/logo_animated/tongues/tongues.gif",
         "/logos/logo_animated/winky/winky.gif",
+        "/logos/logo_animated/jumper/jumper.gif",
+        "/logos/logo_animated/apple/apple.gif",
     )

--- a/bot/seasons/evergreen/__init__.py
+++ b/bot/seasons/evergreen/__init__.py
@@ -6,10 +6,10 @@ class Evergreen(SeasonBase):
 
     bot_icon = "/logos/logo_seasonal/evergreen/logo_evergreen.png"
     icon = (
-        "/logos/logo_animated/heartbeat/heartbeat.gif",
-        "/logos/logo_animated/spinner/spinner.gif",
-        "/logos/logo_animated/tongues/tongues.gif",
-        "/logos/logo_animated/winky/winky.gif",
-        "/logos/logo_animated/jumper/jumper.gif",
-        "/logos/logo_animated/apple/apple.gif",
+        "/logos/logo_animated/heartbeat/heartbeat_512.gif",
+        "/logos/logo_animated/spinner/spinner_512.gif",
+        "/logos/logo_animated/tongues/tongues_512.gif",
+        "/logos/logo_animated/winky/winky_512.gif",
+        "/logos/logo_animated/jumper/jumper_512.gif",
+        "/logos/logo_animated/apple/apple_512.gif",
     )


### PR DESCRIPTION
In https://github.com/python-discord/branding/commit/6b606dd0b3d96d9d59b75686a528261a292e55c1, we have added two new animated logos to the branding repo, however they were not added to the icon constant in seasonalbot, which prevents them from being picked.

This PR adds the two new logos to the constant.

Update: In 7ad0b0a1d6b1d4adbe8dfb9ef6afb9804262aca2, the logos are adjusted to 512 size to (hopefully) prevent a bug where the image doesn't properly display client-side.