### PR TITLE
Advent of Code year binds to datetime instead of a magic number

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -17,7 +17,7 @@ class AdventOfCode:
     leaderboard_id = 631135
     leaderboard_join_code = str(environ.get("AOC_JOIN_CODE", None))
     leaderboard_max_displayed_members = 10
-    year = datetime.utcnow().year
+    year = int(environ.get("AOC_YEAR", datetime.utcnow().year))
     role_id = int(environ.get("AOC_ROLE_ID", 518565788744024082))
 
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -1,6 +1,7 @@
 import logging
 from os import environ
 from typing import NamedTuple
+from datetime import datetime
 
 __all__ = (
     "AdventOfCode", "Channels", "Client", "Colours", "Emojis", "Hacktoberfest", "Roles", "Tokens",
@@ -16,7 +17,7 @@ class AdventOfCode:
     leaderboard_id = 363275
     leaderboard_join_code = str(environ.get("AOC_JOIN_CODE", None))
     leaderboard_max_displayed_members = 10
-    year = 2018
+    year = datetime.utcnow().year
     role_id = int(environ.get("AOC_ROLE_ID", 518565788744024082))
 
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 class AdventOfCode:
     leaderboard_cache_age_threshold_seconds = 3600
-    leaderboard_id = 363275
+    leaderboard_id = 631135
     leaderboard_join_code = str(environ.get("AOC_JOIN_CODE", None))
     leaderboard_max_displayed_members = 10
     year = datetime.utcnow().year


### PR DESCRIPTION
---
name: AoC year fix
issue: Issue #310 
---
 

## Pull Request Details
* Previous the year was a magic number. This PR adds datetime.utcnow() to fix this.
  * Support for an `AOC_YEAR` env var is also added for local debugging
* Leaderboard ID updated

Closes: #310 