### PR TITLE
Update icon path for 2019 festive season

### DIFF
--- a/bot/seasons/christmas/__init__.py
+++ b/bot/seasons/christmas/__init__.py
@@ -22,5 +22,5 @@ class Christmas(SeasonBase):
 
     colour = Colours.dark_green
     icon = (
-        "/logos/logo_seasonal/christmas/festive.png",
+        "/logos/logo_seasonal/christmas/2019/festive_512.gif",
     )


### PR DESCRIPTION
Updates the path to the server icon for the 2019 festive season.

Requires https://github.com/python-discord/branding/pull/38 to be merged first.