### PR TITLE
Fix AOC countdown logic

### DIFF
--- a/bot/resources/advent_of_code/about.json
+++ b/bot/resources/advent_of_code/about.json
@@ -16,7 +16,7 @@
     },
     {
         "name": "How does scoring work?",
-        "value": "Getting a star first is worth 100 points, second is 99, and so on down to 1 point at 100th place.\n\nCheck out AoC's [global leaderboard](https://adventofcode.com/2018/leaderboard) to see who's leading this year's event!",
+        "value": "Getting a star first is worth 100 points, second is 99, and so on down to 1 point at 100th place.\n\nCheck out AoC's [global leaderboard](https://adventofcode.com/leaderboard) to see who's leading this year's event!",
         "inline": false
     },
     {

--- a/bot/seasons/christmas/__init__.py
+++ b/bot/seasons/christmas/__init__.py
@@ -1,3 +1,5 @@
+import datetime
+
 from bot.constants import Colours
 from bot.seasons import SeasonBase
 
@@ -24,3 +26,8 @@ class Christmas(SeasonBase):
     icon = (
         "/logos/logo_seasonal/christmas/2019/festive_512.gif",
     )
+
+    @classmethod
+    def end(cls) -> datetime.datetime:
+        """Overload the `SeasonBase` method to account for the event ending in the next year."""
+        return datetime.datetime.strptime(f"{cls.end_date}/{cls.current_year() + 1}", cls.date_format)

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -170,10 +170,21 @@ class AdventOfCode(commands.Cog):
         """Return time left until next day."""
         if not is_in_advent():
             datetime_now = datetime.now(EST)
-            december_first = datetime(datetime_now.year + 1, 12, 1, tzinfo=EST)
-            delta = december_first - datetime_now
+
+            # Calculate the delta to this & next year's December 1st to see which one is closest and not in the past
+            this_year = datetime(datetime_now.year, 12, 1, tzinfo=EST)
+            next_year = datetime(datetime_now.year + 1, 12, 1, tzinfo=EST)
+            deltas = (dec_first - datetime_now for dec_first in (this_year, next_year))
+            delta = min(delta for delta in deltas if delta >= timedelta())  # timedelta() gives 0 duration delta
+
+            # Add a finer timedelta if there's less than a day left
+            if delta.days == 0:
+                delta_str = f"approximately {delta.seconds // 3600} hours"
+            else:
+                delta_str = f"{delta.days} days"
+
             await ctx.send(f"The Advent of Code event is not currently running. "
-                           f"The next event will start in {delta.days} days.")
+                           f"The next event will start in {delta_str}.")
             return
 
         tomorrow, time_left = time_left_to_aoc_midnight()


### PR DESCRIPTION
The current time delta until the next AOC event assumes that the next event is next year's. While this is was a safe assumption when written, since the command would not be available until the season is loaded on December 1st, it provides an incorrect answer if the season is loaded prior: 

![image](https://user-images.githubusercontent.com/5323929/69905867-502fa080-1388-11ea-8abd-9dcfa9b2a8e5.png)

The logic has been adjusted to return the closest December 1st that is not in the past. The feedback string has also been adjusted to give hours remaining if we're less than a day away from the event starting:

![image](https://user-images.githubusercontent.com/5323929/69905871-5c1b6280-1388-11ea-98f4-f7b61d2fa453.png)
(The second invocation uses November 1st for testing purposes)

The information embed has also been updated to remove the hardcoded year from the link to the global leaderboard. The hardcoded year is unnecessary & the site should redirect to the current event so we don't need to update this value every year.