### PR TITLE
Cancel season related tasks on cog unload

### DIFF
--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -406,7 +406,7 @@ class AdventOfCode(commands.Cog):
             self.cached_global_leaderboard = await AocGlobalLeaderboard.from_url()
         else:
             self.cached_private_leaderboard = await AocPrivateLeaderboard.from_url()
-        
+
     def cog_unload(self) -> None:
         """Cancel season-related tasks on cog unload."""
         self.countdown_task.cancel()

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -406,6 +406,11 @@ class AdventOfCode(commands.Cog):
             self.cached_global_leaderboard = await AocGlobalLeaderboard.from_url()
         else:
             self.cached_private_leaderboard = await AocPrivateLeaderboard.from_url()
+        
+    def cog_unload(self) -> None:
+        """Cancel season-related tasks on cog unload."""
+        self.countdown_task.cancel()
+        self.status_task.cancel()
 
 
 class AocMember:


### PR DESCRIPTION
Right now, two instances of the aoc related asyncio tasks are running at the same time, this PR make sure only one is running. 