### PR TITLE
Add envelope reaction on successful AoC join DM dispatch

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -81,6 +81,7 @@ class Emojis:
     star = "\u2B50"
     christmas_tree = "\U0001F384"
     check = "\u2611"
+    envelope = "\U0001F4E8"
 
     terning1 = "<:terning1:431249668983488527>"
     terning2 = "<:terning2:462339216987127808>"

--- a/bot/seasons/christmas/adventofcode.py
+++ b/bot/seasons/christmas/adventofcode.py
@@ -204,6 +204,8 @@ class AdventOfCode(commands.Cog):
         except discord.errors.Forbidden:
             log.debug(f"{author.name} ({author.id}) has disabled DMs from server members")
             await ctx.send(f":x: {author.mention}, please (temporarily) enable DMs to receive the join code")
+        else:
+            await ctx.message.add_reaction(Emojis.envelope)
 
     @adventofcode_group.command(
         name="leaderboard",


### PR DESCRIPTION
As explained in #322, when a user runs `.aoc join` and their DMs aren't disabled, there is a lack of feedback from the bot. Adding a simple reaction to their message will amend this - it won't look like the bot ignored the request, and we will know that everything went smoothly for the user.

In 40ff465 we add an emoji constant 📨.

In 4af0413 we add an `else` clause to the try-except and add the reaction if everything goes smoothly.

![image](https://user-images.githubusercontent.com/44734341/70000701-cd5f3f00-155b-11ea-9c66-e2a4ba221e61.png)

Closes #322.