### PR TITLE
Make the daily Advent of Code subscription service actually ping subscribers

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -23,7 +23,7 @@ class AdventOfCode:
 
 class Channels(NamedTuple):
     admins = 365960823622991872
-    advent_of_code = 517745814039166986
+    advent_of_code = int(environ.get("AOC_CHANNEL_ID", 517745814039166986))
     announcements = int(environ.get("CHANNEL_ANNOUNCEMENTS", 354619224620138496))
     big_brother_logs = 468507907357409333
     bot = 267659945086812160

--- a/bot/utils/__init__.py
+++ b/bot/utils/__init__.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import re
 import string
 from typing import List
@@ -127,3 +128,25 @@ def replace_many(
             return replacement.lower()
 
     return regex.sub(_repl, sentence)
+
+
+@contextlib.asynccontextmanager
+async def unlocked_role(role: discord.Role, delay: int = 5) -> None:
+    """
+    Create a context in which `role` is unlocked, relocking it automatically after use.
+
+    A configurable `delay` is added before yielding the context and directly after exiting the
+    context to allow the role settings change to properly propagate at Discord's end. This
+    prevents things like role mentions from failing because of synchronization issues.
+
+    Usage:
+    >>> async with unlocked_role(role, delay=5):
+    ...     await ctx.send(f"Hey {role.mention}, free pings for everyone!")
+    """
+    await role.edit(mentionable=True)
+    await asyncio.sleep(delay)
+    try:
+        yield
+    finally:
+        await asyncio.sleep(delay)
+        await role.edit(mentionable=False)


### PR DESCRIPTION
Currently, the message Merrybot sends to announce that a puzzle has become available does not ping the members that have subscribed to these messages. The reason is that we have introduced a more stringent role mentionability policy to prevent abuse; this means that the `Advent of Code`-role is no longer pingable by default. This PR makes sure that the bot unlocks the role before sending such an announcement.

In addition, I've have slightly tweaked the sleep time, since the bot has a history of sending the message slightly too early, and fixed some small mistakes in the code. The puzzle message will now also be sent to the `#advent-of-code` channel.

### Context manager to unlock roles

In order to safely unlock the role, I've written an async context manager that takes care of unlocking and relocking the role and added it to `bot.utils`. The reason for implementing a context manager is because of two complications that need to be taken into account:

1. If a message with a role mention was sent too quickly after unlocking the role, the mention may fail for some users due to synchronization delays. Likewise, if role mentionability is locked too quickly after sending the message, the same synchronization delays may mean the message does not ping the user. As this basic pattern would have to be repeated whenever the bot needs to unlock a role, I figured it was better to factor this out to a context manager.

2. We need to make sure that the role is relocked even if an unexpected exception occurs while it it unlocked to prevent the role from becoming vulnerable to ping abuse. Using a context manager with a `try-finally` block ensures that the role will be locked, even if such an exception happens.

### Verifying the availability of the puzzle

Since Eric, the maker of the Advent of Code, has requested that everyone limits the number of requests made to the Advent of Code server, having the bot send the announcement (slightly) too early could cause a lot of people to request the website when it's not yet available. To prevent this, I've tweaked both the sleep time (since it was consistently 0.5 seconds early) and introduced a bit of logic that makes a HEAD request to the puzzle URL to check if it's already available. While the latter does make a (small) request, it prevents multiple requests from people following the link in our announcement message too early.

### Small changes

While the two background tasks were adjusted for Python 3.7, the new `asyncio.create_task` calls used to schedule them were still wrapped, incorrectly, in the older, lower-level `asyncio.ensure_future` function. I've removed that. 

I've also added a debug logging statement to the `cog_unload` method to track when the cog is being unloaded. This may help with figuring out why Seasonalbot doesn't like the Christmas season.
