### PR TITLE
Use error_embed for errors, tidy code, show cmd signature for user errors.

### DIFF
--- a/bot/seasons/evergreen/error_handler.py
+++ b/bot/seasons/evergreen/error_handler.py
@@ -56,7 +56,7 @@ class CommandErrorHandler(commands.Cog):
             return
 
         if isinstance(error, InChannelCheckFailure):
-            await ctx.send(embed=self.error_embed(str(error), NEGATIVE_REPLIES))
+            await ctx.send(embed=self.error_embed(str(error), NEGATIVE_REPLIES), delete_after=7.5)
             return
 
         if isinstance(error, commands.UserInputError):
@@ -73,7 +73,7 @@ class CommandErrorHandler(commands.Cog):
                 f"This command is on cooldown:\nPlease retry in {mins} minutes {secs} seconds.",
                 NEGATIVE_REPLIES
             )
-            await ctx.send(embed=embed)
+            await ctx.send(embed=embed, delete_after=7.5)
             return
 
         if isinstance(error, commands.DisabledCommand):

--- a/bot/seasons/evergreen/error_handler.py
+++ b/bot/seasons/evergreen/error_handler.py
@@ -1,13 +1,12 @@
 import logging
 import math
 import random
-import sys
-import traceback
+from typing import Iterable, Union
 
-from discord import Colour, Embed, Message
+from discord import Embed, Message
 from discord.ext import commands
 
-from bot.constants import NEGATIVE_REPLIES
+from bot.constants import Colours, ERROR_REPLIES, NEGATIVE_REPLIES
 from bot.decorators import InChannelCheckFailure
 
 log = logging.getLogger(__name__)
@@ -25,92 +24,80 @@ class CommandErrorHandler(commands.Cog):
         if command._buckets.valid:
             bucket = command._buckets.get_bucket(message)
             bucket._tokens = min(bucket.rate, bucket._tokens + 1)
-            logging.debug(
-                "Cooldown counter reverted as the command was not used correctly."
-            )
+            logging.debug("Cooldown counter reverted as the command was not used correctly.")
+
+    @staticmethod
+    def error_embed(message: str, title: Union[Iterable, str] = ERROR_REPLIES) -> Embed:
+        """Build a basic embed with red colour and either a random error title or a title provided."""
+        embed = Embed(colour=Colours.soft_red)
+        if isinstance(title, str):
+            embed.title = title
+        else:
+            embed.title = random.choice(title)
+        embed.description = message
+        return embed
 
     @commands.Cog.listener()
     async def on_command_error(self, ctx: commands.Context, error: commands.CommandError) -> None:
         """Activates when a command opens an error."""
         if hasattr(ctx.command, 'on_error'):
-            return logging.debug(
-                "A command error occured but the command had it's own error handler."
-            )
+            logging.debug("A command error occured but the command had it's own error handler.")
+            return
 
         error = getattr(error, 'original', error)
-
-        if isinstance(error, InChannelCheckFailure):
-            logging.debug(
-                f"{ctx.author} the command '{ctx.command}', but they did not have "
-                f"permissions to run commands in the channel {ctx.channel}!"
-            )
-            embed = Embed(colour=Colour.red())
-            embed.title = random.choice(NEGATIVE_REPLIES)
-            embed.description = str(error)
-            return await ctx.send(embed=embed)
+        logging.debug(
+            f"Error Encountered: {type(error).__name__} - {str(error)}, "
+            f"Command: {ctx.command}, "
+            f"Author: {ctx.author}, "
+            f"Channel: {ctx.channel}"
+        )
 
         if isinstance(error, commands.CommandNotFound):
-            return logging.debug(
-                f"{ctx.author} called '{ctx.message.content}' but no command was found."
-            )
+            return
+
+        if isinstance(error, InChannelCheckFailure):
+            await ctx.send(embed=self.error_embed(str(error), NEGATIVE_REPLIES))
+            return
 
         if isinstance(error, commands.UserInputError):
-            logging.debug(
-                f"{ctx.author} called the command '{ctx.command}' but entered invalid input!"
-            )
-
             self.revert_cooldown_counter(ctx.command, ctx.message)
-
-            return await ctx.send(
-                ":no_entry: The command you specified failed to run. "
-                "This is because the arguments you provided were invalid."
+            embed = self.error_embed(
+                f"Your input was invalid: {error}\n\nUsage:\n```{ctx.prefix}{ctx.command} {ctx.command.signature}```"
             )
+            await ctx.send(embed=embed)
+            return
 
         if isinstance(error, commands.CommandOnCooldown):
-            logging.debug(
-                f"{ctx.author} called the command '{ctx.command}' but they were on cooldown!"
+            mins, secs = divmod(math.ceil(error.retry_after), 60)
+            embed = self.error_embed(
+                f"This command is on cooldown:\nPlease retry in {mins} minutes {secs} seconds.",
+                NEGATIVE_REPLIES
             )
-            remaining_minutes, remaining_seconds = divmod(error.retry_after, 60)
-
-            return await ctx.send(
-                "This command is on cooldown, please retry in "
-                f"{int(remaining_minutes)} minutes {math.ceil(remaining_seconds)} seconds."
-            )
+            await ctx.send(embed=embed)
+            return
 
         if isinstance(error, commands.DisabledCommand):
-            logging.debug(
-                f"{ctx.author} called the command '{ctx.command}' but the command was disabled!"
-            )
-            return await ctx.send(":no_entry: This command has been disabled.")
+            await ctx.send(embed=self.error_embed("This command has been disabled.", NEGATIVE_REPLIES))
+            return
 
         if isinstance(error, commands.NoPrivateMessage):
-            logging.debug(
-                f"{ctx.author} called the command '{ctx.command}' "
-                "in a private message however the command was guild only!"
-            )
-            return await ctx.author.send(":no_entry: This command can only be used in the server.")
+            await ctx.send(embed=self.error_embed("This command can only be used in the server.", NEGATIVE_REPLIES))
+            return
 
         if isinstance(error, commands.BadArgument):
             self.revert_cooldown_counter(ctx.command, ctx.message)
-
-            logging.debug(
-                f"{ctx.author} called the command '{ctx.command}' but entered a bad argument!"
+            embed = self.error_embed(
+                "The argument you provided was invalid: "
+                f"{error}\n\nUsage:\n```{ctx.prefix}{ctx.command} {ctx.command.signature}```"
             )
-            return await ctx.send("The argument you provided was invalid.")
+            await ctx.send(embed=embed)
+            return
 
         if isinstance(error, commands.CheckFailure):
-            logging.debug(f"{ctx.author} called the command '{ctx.command}' but the checks failed!")
-            return await ctx.send(":no_entry: You are not authorized to use this command.")
+            await ctx.send(embed=self.error_embed("You are not authorized to use this command.", NEGATIVE_REPLIES))
+            return
 
-        print(f"Ignoring exception in command {ctx.command}:", file=sys.stderr)
-
-        logging.warning(
-            f"{ctx.author} called the command '{ctx.command}' "
-            "however the command failed to run with the error:"
-            f"-------------\n{error}"
-        )
-
-        traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)
+        log.exception(f"Unhandled command error: {str(error)}")
 
 
 def setup(bot: commands.Bot) -> None:

--- a/bot/seasons/evergreen/error_handler.py
+++ b/bot/seasons/evergreen/error_handler.py
@@ -97,7 +97,7 @@ class CommandErrorHandler(commands.Cog):
             await ctx.send(embed=self.error_embed("You are not authorized to use this command.", NEGATIVE_REPLIES))
             return
 
-        log.exception(f"Unhandled command error: {str(error)}")
+        log.exception(f"Unhandled command error: {str(error)}", exc_info=error)
 
 
 def setup(bot: commands.Bot) -> None:


### PR DESCRIPTION
## Related Issues
Closes #307 

## Description of Changes
- CRLF (Windows) line separators changed to LF (Unix)
- Create `error_embed` classmethod to build error embeds consistently
- Make all handled error types use `error_embed` method for any user responses
- Remove error-specific debug log messages and have a generic debug log at the top
- Log unhandled errors with `log.exception` instead of using `logging.warning`
- Have full traceback shown in stderr with `log.exception` by passing `exc_info`
- Use `math.ceil` on `retry_after` instead of within f-string to be cleaner
- Have the command signature sent to show how to use it when users invoke it incorrectly (`UserInputError`, `BadArgument`)
- Make channel check errors delete themselves after 7.5 seconds (as per suggestion from lemon)

## Reasoning

### CRLF to LF
Our projects use LF line separators and it seems sometime in the past CRLF was accidentally committed. This was brought back inline for consistency.

### Error message consistency
Some errors shown an embed, others didn't. This brings everything back together to be the same and to make use of the random error titles with `ERROR_REPLIES` used by default and `NEGATIVE_REPLIES` able to be used for errors caused by permissions/checks/cooldowns.

### Error specific logs
If all are logged, there's really no need for each to have one.

### Using `log.exception` with full traceback
Previously errors looked like this during development:
```
seasonalbot    | Ignoring exception in command roll:
seasonalbot    | 12/12/19 02:55:20 - root WARNING: Scragly#5146 called the command 'roll' however the command failed to run with the error:-------------
seasonalbot    | this is a test exception
```
To be honest, it's pretty useless. It doesn't tell us where the error is located, on what line and what lead up to the event.

With the changes we have instead:
```
seasonalbot    | 12/12/19 02:58:09 - root DEBUG: Error Encountered: OSError - this is a test exception, Command: roll, Author: Scragly#5146, Channel: bot
seasonalbot    | 12/12/19 02:58:09 - bot.seasons.evergreen.error_handler ERROR: Unhandled command error: this is a test exception
seasonalbot    | Traceback (most recent call last):
seasonalbot    |   File "/usr/local/lib/python3.7/site-packages/discord/ext/commands/core.py", line 79, in wrapped
seasonalbot    |     ret = await coro(*args, **kwargs)
seasonalbot    |   File "/bot/bot/seasons/evergreen/fun.py", line 38, in roll
seasonalbot    |     raise OSError("this is a test exception")
seasonalbot    | OSError: this is a test exception
```
Which is far more useful during development or even when just needing to look back on log output generally for unhandled cases.

### Use math.ceil on `retry_after`
Doing so reduced the code from:
```py
remaining_minutes, remaining_seconds = divmod(error.retry_after, 60)
return await ctx.send(
    "This command is on cooldown, please retry in "
    f"{int(remaining_minutes)} minutes {math.ceil(remaining_seconds)} seconds."
)
```
to the alternative which shortens the var names and removes the unnecessary int cast:
```py
mins, secs = divmod(math.ceil(error.retry_after), 60)
embed = self.error_embed(
    f"This command is on cooldown:\nPlease retry in {mins} minutes {secs} seconds.",
    NEGATIVE_REPLIES
)
```

### Show command signature on user invoke error
The current output when a command is used incorrectly is:
![image](https://user-images.githubusercontent.com/29337040/70679967-79362680-1ce2-11ea-9c32-f5fe1f07ef08.png)

This isn't too useful to new users, as then they'd likely have to manually use `.help commandname` which is just another step, or they'd keep guessing.

Instead this was changed to show the proper usage:
![image](https://user-images.githubusercontent.com/29337040/70680036-a256b700-1ce2-11ea-9c8a-e8aac7d734be.png)


## Did you:
- [x] Join the [PythonDiscord Community](https://pythondiscord.com/invite)?
- [x] Make changes in the **Pipenv** environment?
- [x] **Lint your code** and make sure it passes? (```pipenv run lint```)