### PR TITLE
Add exception where relayed message.content length exceed 2048 charac…

### DIFF
--- a/bot/seasons/evergreen/bookmark.py
+++ b/bot/seasons/evergreen/bookmark.py
@@ -25,11 +25,10 @@ class Bookmark(commands.Cog):
     ) -> None:
         """Send the author a link to `target_message` via DMs."""
         log.info(f"{ctx.author} bookmarked {target_message.jump_url} with title '{title}'")
-        content = target_message.content
         embed = discord.Embed(
             title=title,
             colour=Colours.soft_green,
-            description=content
+            description=target_message.content
         )
         embed.add_field(name="Wanna give it a visit?", value=f"[Visit original message]({target_message.jump_url})")
         embed.set_author(name=target_message.author, icon_url=target_message.author.avatar_url)

--- a/bot/seasons/evergreen/bookmark.py
+++ b/bot/seasons/evergreen/bookmark.py
@@ -25,11 +25,14 @@ class Bookmark(commands.Cog):
     ) -> None:
         """Send the author a link to `target_message` via DMs."""
         log.info(f"{ctx.author} bookmarked {target_message.jump_url} with title '{title}'")
+        content = target_message.content
+        if len(content) > 250:
+            content = content[:250]+'......'
         embed = discord.Embed(
             title=title,
             colour=Colours.soft_green,
             description=(
-                f"{target_message.content}\n\n"
+                f"{content}\n\n"
                 f"[Visit original message]({target_message.jump_url})"
             )
         )

--- a/bot/seasons/evergreen/bookmark.py
+++ b/bot/seasons/evergreen/bookmark.py
@@ -26,16 +26,12 @@ class Bookmark(commands.Cog):
         """Send the author a link to `target_message` via DMs."""
         log.info(f"{ctx.author} bookmarked {target_message.jump_url} with title '{title}'")
         content = target_message.content
-        if len(content) > 250:
-            content = content[:250]+'......'
         embed = discord.Embed(
             title=title,
             colour=Colours.soft_green,
-            description=(
-                f"{content}\n\n"
-                f"[Visit original message]({target_message.jump_url})"
-            )
+            description=content
         )
+        embed.add_field(name="Wanna give it a visit?", value=f"[Visit original message]({target_message.jump_url})")
         embed.set_author(name=target_message.author, icon_url=target_message.author.avatar_url)
         embed.set_thumbnail(url=bookmark_icon_url)
 


### PR DESCRIPTION
…ters

---
name: Exception of character limits
about: Resolve a issue where bookmarked message content is near 2048
issue: Issue #336 

---

## Pull Request Details

Please ensure your PR fulfills the following criteria:

- [check] Have you joined the [PythonDiscord Community](https://pythondiscord.com/invite)?
- [check] Were your changes made in a Pipenv environment?
- [check] Does flake8 pass (```pipenv run lint```)


## Additional information

New message should look like this

An '.....' is pretty much enough to indicate user that there is more.
<img width="338" alt="Screenshot_88" src="https://user-images.githubusercontent.com/45149585/71840481-677a5000-30e3-11ea-9e5b-8f07e4625cef.png">
