### PR TITLE
Added  permission check for staff channels message leak.

### DIFF
--- a/bot/seasons/evergreen/bookmark.py
+++ b/bot/seasons/evergreen/bookmark.py
@@ -24,16 +24,15 @@ class Bookmark(commands.Cog):
         title: str = "Bookmark"
     ) -> None:
         """Send the author a link to `target_message` via DMs."""
-        log.info(f"{ctx.author} bookmarked {target_message.jump_url} with title '{title}'")
+        # Prevent users from bookmarking a message in a channel they don't have access to
         permissions = ctx.author.permissions_in(target_message.channel)
         if not permissions.read_messages:
+            log.info(f"{ctx.author} tried to bookmark a message in #{target_message.channel} but has no permissions")
             embed = discord.Embed(
                 title=random.choice(ERROR_REPLIES),
                 color=Colours.soft_red,
-                description="You don't have permission to see what's in the channel so you can't "
-                            "bookmark a message from it."
+                description="You don't have permission to view this channel."
             )
-            embed.set_author(name=ctx.author.name, icon_url=ctx.author.avatar_url)
             await ctx.send(embed=embed)
             return
 
@@ -56,6 +55,7 @@ class Bookmark(commands.Cog):
             )
             await ctx.send(embed=error_embed)
         else:
+            log.info(f"{ctx.author} bookmarked {target_message.jump_url} with title '{title}'")
             await ctx.message.add_reaction(Emojis.envelope)
 
 

--- a/bot/seasons/evergreen/bookmark.py
+++ b/bot/seasons/evergreen/bookmark.py
@@ -25,6 +25,18 @@ class Bookmark(commands.Cog):
     ) -> None:
         """Send the author a link to `target_message` via DMs."""
         log.info(f"{ctx.author} bookmarked {target_message.jump_url} with title '{title}'")
+        permissions = ctx.author.permissions_in(target_message.channel)
+        if not permissions.read_messages:
+            embed = discord.Embed(
+                title=random.choice(ERROR_REPLIES),
+                color=Colours.soft_red,
+                description="You don't have permission to see what's in the channel so you can't "
+                            "bookmark a message from it."
+            )
+            embed.set_author(name=ctx.author.name, icon_url=ctx.author.avatar_url)
+            await ctx.send(embed=embed)
+            return
+
         embed = discord.Embed(
             title=title,
             colour=Colours.soft_green,


### PR DESCRIPTION
---
name: Fix to prevent leaking of staff channel leaks.
issue: #339 

---

This PR adds a permissions check to prevent users from bookmarking a message from a channel they do not have read permissions for. Because the bot has permissions in these channels, it can leak message contents to the user via DM

Closes: #339 

## Pull Request Details

Please ensure your PR fulfills the following criteria:

- [x] Have you joined the [PythonDiscord Community](https://pythondiscord.com/invite)?
- [x] Were your changes made in a Pipenv environment?
- [x] Does flake8 pass (```pipenv run lint```)


