### PR TITLE
Check if channel exists before referencing it

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -36,7 +36,6 @@ class Channels(NamedTuple):
     checkpoint_test = 422077681434099723
     devalerts = 460181980097675264
     devlog = int(environ.get("CHANNEL_DEVLOG", 548438471685963776))
-    devtest = 414574275865870337
     help_0 = 303906576991780866
     help_1 = 303906556754395136
     help_2 = 303906514266226689
@@ -142,7 +141,6 @@ STAFF_ROLES = Roles.helpers, Roles.moderator, Roles.admin, Roles.owner
 WHITELISTED_CHANNELS = (
     Channels.bot, Channels.seasonalbot_commands,
     Channels.off_topic_0, Channels.off_topic_1, Channels.off_topic_2,
-    Channels.devtest,
 )
 
 # Bot replies

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -88,6 +88,8 @@ def in_channel_check(*channels: int, bypass_roles: typing.Container[int] = None)
             )
             return True
 
+        guild_channels = [channel.id for channel in ctx.guild.channels]
+
         if hasattr(ctx.command.callback, "in_channel_override"):
             override = ctx.command.callback.in_channel_override
             if override is None:
@@ -108,7 +110,7 @@ def in_channel_check(*channels: int, bypass_roles: typing.Container[int] = None)
                     f"{ctx.author} tried to call the '{ctx.command.name}' command. "
                     f"The overridden in_channel check failed."
                 )
-                channels_str = ', '.join(f"<#{c_id}>" for c_id in override)
+                channels_str = ', '.join(f"<#{c_id}>" for c_id in override if c_id in guild_channels)
                 raise InChannelCheckFailure(
                     f"Sorry, but you may only use this command within {channels_str}."
                 )
@@ -118,7 +120,7 @@ def in_channel_check(*channels: int, bypass_roles: typing.Container[int] = None)
             f"The in_channel check failed."
         )
 
-        channels_str = ', '.join(f"<#{c_id}>" for c_id in channels)
+        channels_str = ', '.join(f"<#{c_id}>" for c_id in channels if c_id in guild_channels)
         raise InChannelCheckFailure(
             f"Sorry, but you may only use this command within {channels_str}."
         )

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -88,8 +88,6 @@ def in_channel_check(*channels: int, bypass_roles: typing.Container[int] = None)
             )
             return True
 
-        guild_channels = [channel.id for channel in ctx.guild.channels]
-
         if hasattr(ctx.command.callback, "in_channel_override"):
             override = ctx.command.callback.in_channel_override
             if override is None:
@@ -110,7 +108,7 @@ def in_channel_check(*channels: int, bypass_roles: typing.Container[int] = None)
                     f"{ctx.author} tried to call the '{ctx.command.name}' command. "
                     f"The overridden in_channel check failed."
                 )
-                channels_str = ', '.join(f"<#{c_id}>" for c_id in override if c_id in guild_channels)
+                channels_str = ', '.join(f"<#{c_id}>" for c_id in override)
                 raise InChannelCheckFailure(
                     f"Sorry, but you may only use this command within {channels_str}."
                 )
@@ -120,7 +118,7 @@ def in_channel_check(*channels: int, bypass_roles: typing.Container[int] = None)
             f"The in_channel check failed."
         )
 
-        channels_str = ', '.join(f"<#{c_id}>" for c_id in channels if c_id in guild_channels)
+        channels_str = ', '.join(f"<#{c_id}>" for c_id in channels)
         raise InChannelCheckFailure(
             f"Sorry, but you may only use this command within {channels_str}."
         )


### PR DESCRIPTION
---
name: Check if channel exists before referencing it
about: Avoid referencing #invalid-channel
closes: #335 

---

## Pull Request Details

Please ensure your PR fulfills the following criteria:

- [x] Have you joined the [PythonDiscord Community](https://pythondiscord.com/invite)?
- [x] Were your changes made in a Pipenv environment?
- [x] Does flake8 pass (```pipenv run lint```)