### PR TITLE
Icon switch frequency

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -69,6 +69,7 @@ class Client(NamedTuple):
     token = environ.get("SEASONALBOT_TOKEN")
     debug = environ.get("SEASONALBOT_DEBUG", "").lower() == "true"
     season_override = environ.get("SEASON_OVERRIDE")
+    icon_cycle_frequency = 3  # N days to wait between cycling server icons within a single season
 
 
 class Colours:

--- a/bot/seasons/season.py
+++ b/bot/seasons/season.py
@@ -386,7 +386,7 @@ class SeasonManager(commands.Cog):
 
         while True:
             await asyncio.sleep(self.sleep_time)  # Sleep until midnight
-            self.sleep_time = 86400  # Next time, sleep for 24 hours.
+            self.sleep_time = 24 * 3600  # Next time, sleep for 24 hours
 
             # If the season has changed, load it.
             new_season = get_season(date=datetime.datetime.utcnow())

--- a/bot/seasons/season.py
+++ b/bot/seasons/season.py
@@ -383,18 +383,29 @@ class SeasonManager(commands.Cog):
         """Asynchronous timer loop to check for a new season every midnight."""
         await self.bot.wait_until_ready()
         await self.season.load()
+        days_since_icon_change = 0
 
         while True:
             await asyncio.sleep(self.sleep_time)  # Sleep until midnight
             self.sleep_time = 24 * 3600  # Next time, sleep for 24 hours
+
+            days_since_icon_change += 1
+            log.debug(f"Days since last icon change: {days_since_icon_change}")
 
             # If the season has changed, load it.
             new_season = get_season(date=datetime.datetime.utcnow())
             if new_season.name != self.season.name:
                 self.season = new_season
                 await self.season.load()
+                days_since_icon_change = 0  # Start counting afresh for the new season
+
+            # Otherwise we check whether it's time for an icon cycle within the current season
             else:
-                await self.season.change_server_icon()
+                if days_since_icon_change == Client.icon_cycle_frequency:
+                    await self.season.change_server_icon()
+                    days_since_icon_change = 0
+                else:
+                    log.debug(f"Waiting {Client.icon_cycle_frequency - days_since_icon_change} more days to cycle icon")
 
     @with_role(Roles.moderator, Roles.admin, Roles.owner)
     @commands.command(name="season")


### PR DESCRIPTION
Adds a configurable constant, which determines the amount of days to wait between cycling icons within a single season. See my conversation with lemon: https://github.com/python-discord/organisation/issues/191#issuecomment-590086579 and below.

@lemonsaurus I liked your suggestion with using `itertools.cycle`, but I decided to just keep internal state as an int. The reason here is that we can easily reset it back to 0 if we switch seasons.

I tried to keep the implementation as simple as possible. It can be tested by manually setting `sleep_time` to a few seconds. Running this loop with a `sleep_time` forced to 3 seconds and logging set to `DEBUG` produces the following output.

```
02/23/20 20:03:41 - bot.seasons.season DEBUG: Days since last icon change: 1
02/23/20 20:03:41 - bot.seasons.season DEBUG: Waiting 2 more days to cycle icon
02/23/20 20:03:44 - bot.seasons.season DEBUG: Days since last icon change: 2
02/23/20 20:03:44 - bot.seasons.season DEBUG: Waiting 1 more days to cycle icon
02/23/20 20:03:47 - bot.seasons.season DEBUG: Days since last icon change: 3
02/23/20 20:03:50 - bot.seasons.season DEBUG: Days since last icon change: 1
02/23/20 20:03:50 - bot.seasons.season DEBUG: Waiting 2 more days to cycle icon
02/23/20 20:03:53 - bot.seasons.season DEBUG: Days since last icon change: 2
02/23/20 20:03:53 - bot.seasons.season DEBUG: Waiting 1 more days to cycle icon
02/23/20 20:03:56 - bot.seasons.season DEBUG: Days since last icon change: 3
02/23/20 20:03:59 - bot.seasons.season DEBUG: Days since last icon change: 1
02/23/20 20:03:59 - bot.seasons.season DEBUG: Waiting 2 more days to cycle icon
```

## Considerations
Have I chosen a good place for the constant? Should it be configurable via an environmental var, like the other constants in `Client`?