### PR TITLE
Add `data` persistence directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # bot (project-specific)
 log/*
+data/*
 
 
 


### PR DESCRIPTION
Closes #379

Make git ignore the directory that the persistence module writes to. Prevents accidentally adding it to version control.