### PR TITLE
Add a command to look for Game Jam 2020 teammates

### DIFF
--- a/bot/seasons/evergreen/codejam.py
+++ b/bot/seasons/evergreen/codejam.py
@@ -8,14 +8,15 @@ from discord.ext import commands
 
 
 class MatchMakingAlgo(commands.Cog):
-    """Defines the matchmaking algorithm"""
+    """Defines the matchmaking algorithm."""
+
     def __init__(self, bot: commands.Bot) -> None:
-        """Creates matchmaking pool"""
+        """Creates matchmaking pool."""
         self.bot = bot
         self.matchmaking_pool = []
 
     async def search_teammate(self) -> Union[User, None]:
-        """Looks for a teammate in the matchmaking pool"""
+        """Looks for a teammate in the matchmaking pool."""
         if self.matchmaking_pool == []:
             await asyncio.sleep(5)
             return await self.search_teammate()
@@ -24,7 +25,7 @@ class MatchMakingAlgo(commands.Cog):
 
     @commands.command()
     async def find_teammate(self, ctx: commands.Context) -> None:
-        """Direct command to look for a teammate"""
+        """Direct command to look for a teammate."""
         self.matchmaking_pool.append(ctx.author)
         embed = discord.Embed(title="Searcing for a teammate...",
                               color=0xFF0000)
@@ -38,5 +39,5 @@ class MatchMakingAlgo(commands.Cog):
 
 
 def setup(bot: commands.Bot) -> None:
-    """Setups the bot"""
+    """Setups the bot."""
     bot.add_cog(MatchMakingAlgo(bot))

--- a/bot/seasons/evergreen/codejam.py
+++ b/bot/seasons/evergreen/codejam.py
@@ -8,11 +8,14 @@ from discord.ext import commands
 
 
 class MatchMakingAlgo(commands.Cog):
-    def __init__(self, bot: commands.Bot):
+    """Defines the matchmaking algorithm"""
+    def __init__(self, bot: commands.Bot) -> None:
+        """Creates matchmaking pool"""
         self.bot = bot
         self.matchmaking_pool = []
 
     async def search_teammate(self) -> Union[User, None]:
+        """Looks for a teammate in the matchmaking pool"""
         if self.matchmaking_pool == []:
             await asyncio.sleep(5)
             return await self.search_teammate()
@@ -21,6 +24,7 @@ class MatchMakingAlgo(commands.Cog):
 
     @commands.command()
     async def find_teammate(self, ctx: commands.Context) -> None:
+        """Direct command to look for a teammate"""
         self.matchmaking_pool.append(ctx.author)
         embed = discord.Embed(title="Searcing for a teammate...",
                               color=0xFF0000)
@@ -34,4 +38,5 @@ class MatchMakingAlgo(commands.Cog):
 
 
 def setup(bot: commands.Bot) -> None:
+    """Setups the bot"""
     bot.add_cog(MatchMakingAlgo(bot))

--- a/bot/seasons/evergreen/codejam.py
+++ b/bot/seasons/evergreen/codejam.py
@@ -1,0 +1,37 @@
+import asyncio
+import random
+from typing import Union
+
+import discord
+from discord import User
+from discord.ext import commands
+
+
+class MatchMakingAlgo(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.matchmaking_pool = []
+
+    async def search_teammate(self) -> Union[User, None]:
+        if self.matchmaking_pool == []:
+            await asyncio.sleep(5)
+            return await self.search_teammate()
+        t = random.choice(self.matchmaking_pool())
+        return self.matchmaking_pool.pop(t, None)
+
+    @commands.command()
+    async def find_teammate(self, ctx: commands.Context) -> None:
+        self.matchmaking_pool.append(ctx.author)
+        embed = discord.Embed(title="Searcing for a teammate...",
+                              color=0xFF0000)
+        message: discord.Message = await ctx.send(embed=embed)
+        teammate = self.search_teammate()
+        embed = discord.Embed(title="Teammate found!",
+                              color=0x00FF00)
+        await message.edit(content=f"Hello {teammate.mention} and"
+                                   f"{ctx.user.mention}",
+                                   embed=embed)
+
+
+def setup(bot: commands.Bot) -> None:
+    bot.add_cog(MatchMakingAlgo(bot))


### PR DESCRIPTION
This adds a command that searches for teammates

## Relevant Issues
None


## Description
I've added a little matchmaking pool and a command that searches for users.

## Reasoning
The #game-gam channel is filled with people looking for teammates so i figured, this could be automated!


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [X ] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X ] If dependencies have been added or updated, run `pipenv lock`?
- [X ] **Lint your code** (`pipenv run lint`)?
- [ X] Set the PR to **allow edits from contributors**?
