### PR TITLE
Send greeting message on bot start-up

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -44,6 +44,7 @@ class SeasonalBot(commands.Bot):
         self.http_session = ClientSession(
             connector=TCPConnector(resolver=AsyncResolver(), family=socket.AF_INET)
         )
+        self.greeting_task = self.loop.create_task(self.send_log("SeasonalBot", "Connected!"))
 
     @property
     def member(self) -> Optional[discord.Member]:

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -44,7 +44,7 @@ class SeasonalBot(commands.Bot):
         self.http_session = ClientSession(
             connector=TCPConnector(resolver=AsyncResolver(), family=socket.AF_INET)
         )
-        self.greeting_task = self.loop.create_task(self.send_log("SeasonalBot", "Connected!"))
+        self.loop.create_task(self.send_log("SeasonalBot", "Connected!"))
 
     @property
     def member(self) -> Optional[discord.Member]:

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -148,6 +148,7 @@ class SeasonalBot(commands.Bot):
 
     async def send_log(self, title: str, details: str = None, *, icon: str = None) -> None:
         """Send an embed message to the devlog channel."""
+        await self.wait_until_ready()
         devlog = self.get_channel(Channels.devlog)
 
         if not devlog:


### PR DESCRIPTION
Closes #390 

The issue gives a fairly though explanation. Implementation is simple, as we already have a method for dispatching embeds to the `#dev-log` channel. In 6af47f8, we first ensure that the cache is ready before grabbing the devlog channel instance.

![image](https://user-images.githubusercontent.com/44734341/78403448-ac3b5780-75fc-11ea-8ee8-23419c6aaca0.png)

The author field is always populated with `SeasonalBot` - the seasonal nickname isn't used.
