### PR TITLE
handle disabled DMs when starting Minesweeper

### DIFF
--- a/bot/exts/evergreen/minesweeper.py
+++ b/bot/exts/evergreen/minesweeper.py
@@ -151,11 +151,16 @@ class Minesweeper(commands.Cog):
         else:
             chat_msg = None
 
-        await ctx.author.send(
-            f"Play by typing: `{Client.prefix}ms reveal xy [xy]` or `{Client.prefix}ms flag xy [xy]` \n"
-            f"Close the game with `{Client.prefix}ms end`\n"
-        )
-        dm_msg = await ctx.author.send(f"Here's your board!\n{self.format_for_discord(revealed_board)}")
+        try:
+            await ctx.author.send(
+                f"Play by typing: `{Client.prefix}ms reveal xy [xy]` or `{Client.prefix}ms flag xy [xy]` \n"
+                f"Close the game with `{Client.prefix}ms end`\n"
+            )
+        except discord.errors.Forbidden:
+            log.debug(f"{ctx.author.name} ({ctx.author.id}) has disabled DMs from server members")
+            await ctx.send(f":x: {ctx.author.mention}, please (temporarily) enable DMs to receive the join code")
+        else:
+            dm_msg = await ctx.author.send(f"Here's your board!\n{self.format_for_discord(revealed_board)}")
 
         self.games[ctx.author.id] = Game(
             board=board,

--- a/bot/exts/evergreen/minesweeper.py
+++ b/bot/exts/evergreen/minesweeper.py
@@ -158,7 +158,7 @@ class Minesweeper(commands.Cog):
             )
         except discord.errors.Forbidden:
             log.debug(f"{ctx.author.name} ({ctx.author.id}) has disabled DMs from server members")
-            await ctx.send(f":x: {ctx.author.mention}, please (temporarily) enable DMs to receive the join code")
+            await ctx.send(f":x: {ctx.author.mention}, please enable DMs to play minesweeper.")
         else:
             dm_msg = await ctx.author.send(f"Here's your board!\n{self.format_for_discord(revealed_board)}")
 

--- a/bot/exts/evergreen/minesweeper.py
+++ b/bot/exts/evergreen/minesweeper.py
@@ -141,16 +141,6 @@ class Minesweeper(commands.Cog):
             await ctx.message.delete(delay=2)
             return
 
-        # Add game to list
-        board: GameBoard = self.generate_board(bomb_chance)
-        revealed_board: GameBoard = [["hidden"] * 10 for _ in range(10)]
-
-        if ctx.guild:
-            await ctx.send(f"{ctx.author.mention} is playing Minesweeper")
-            chat_msg = await ctx.send(f"Here's there board!\n{self.format_for_discord(revealed_board)}")
-        else:
-            chat_msg = None
-
         try:
             await ctx.author.send(
                 f"Play by typing: `{Client.prefix}ms reveal xy [xy]` or `{Client.prefix}ms flag xy [xy]` \n"
@@ -159,8 +149,18 @@ class Minesweeper(commands.Cog):
         except discord.errors.Forbidden:
             log.debug(f"{ctx.author.name} ({ctx.author.id}) has disabled DMs from server members")
             await ctx.send(f":x: {ctx.author.mention}, please enable DMs to play minesweeper.")
+            return
+
+        # Add game to list
+        board: GameBoard = self.generate_board(bomb_chance)
+        revealed_board: GameBoard = [["hidden"] * 10 for _ in range(10)]
+        dm_msg = await ctx.author.send(f"Here's your board!\n{self.format_for_discord(revealed_board)}")
+
+        if ctx.guild:
+            await ctx.send(f"{ctx.author.mention} is playing Minesweeper")
+            chat_msg = await ctx.send(f"Here's there board!\n{self.format_for_discord(revealed_board)}")
         else:
-            dm_msg = await ctx.author.send(f"Here's your board!\n{self.format_for_discord(revealed_board)}")
+            chat_msg = None
 
         self.games[ctx.author.id] = Game(
             board=board,


### PR DESCRIPTION
If the user trying to start Minesweeper has DMs disabled
then warn him in the channel where the command was
invoked.

## Relevant Issues
Closes #399 

## Description
To fix this we check for `discord.errors.Forbidden` after sending the DM and inform the user if he has DMs disabled.


## Reasoning
Currently if user has DMs disabled the script fails silently without informing him of any issues.


## Did you:
- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
