### PR TITLE
Handle staff users and DMs in the halloweenify cog

### DIFF
--- a/bot/exts/halloween/halloweenify.py
+++ b/bot/exts/halloween/halloweenify.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from random import choice
 
 import discord
+from discord.errors import Forbidden
 from discord.ext import commands
 from discord.ext.commands.cooldowns import BucketType
 
@@ -37,11 +38,25 @@ class Halloweenify(commands.Cog):
                 f"**{ctx.author.display_name}** wasn\'t spooky enough for you? That\'s understandable, "
                 f"{ctx.author.display_name} isn\'t scary at all! "
                 "Let me think of something better. Hmm... I got it!\n\n "
-                f"Your new nickname will be: \n :ghost: **{nickname}** :jack_o_lantern:"
             )
             embed.set_image(url=image)
 
-            await ctx.author.edit(nick=nickname)
+            try:
+                if isinstance(ctx.author, discord.Member):
+                    await ctx.author.edit(nick=nickname)
+                    embed.description += f"Your new nickname will be: \n:ghost: **{nickname}** :jack_o_lantern:"
+
+                else:   # The command has been invoked in DM
+                    embed.description += (
+                        f"Your new nickname should be: \n :ghost: **{nickname}** :jack_o_lantern: \n\n"
+                        f"Feel free to change it yourself, or invoke the command again inside the server."
+                    )
+
+            except Forbidden:   # The bot doesn't have enough permission
+                embed.description += (
+                    f"Your new nickname should be: \n :ghost: **{nickname}** :jack_o_lantern: \n\n"
+                    f"Although it looks like I can't change it myself, but feel free to change it yourself."
+                )
 
         await ctx.send(embed=embed)
 

--- a/bot/exts/halloween/halloweenify.py
+++ b/bot/exts/halloween/halloweenify.py
@@ -41,21 +41,21 @@ class Halloweenify(commands.Cog):
             )
             embed.set_image(url=image)
 
-            try:
-                if isinstance(ctx.author, discord.Member):
+            if isinstance(ctx.author, discord.Member):
+                try:
                     await ctx.author.edit(nick=nickname)
                     embed.description += f"Your new nickname will be: \n:ghost: **{nickname}** :jack_o_lantern:"
 
-                else:   # The command has been invoked in DM
+                except Forbidden:   # The bot doesn't have enough permission
                     embed.description += (
                         f"Your new nickname should be: \n :ghost: **{nickname}** :jack_o_lantern: \n\n"
-                        f"Feel free to change it yourself, or invoke the command again inside the server."
+                        f"It looks like I cannot change your name, but feel free to change it yourself."
                     )
 
-            except Forbidden:   # The bot doesn't have enough permission
+            else:   # The command has been invoked in DM
                 embed.description += (
                     f"Your new nickname should be: \n :ghost: **{nickname}** :jack_o_lantern: \n\n"
-                    f"Although it looks like I can't change it myself, but feel free to change it yourself."
+                    f"Feel free to change it yourself, or invoke the command again inside the server."
                 )
 
         await ctx.send(embed=embed)


### PR DESCRIPTION
## Relevant Issues
<!-- List relevant issue tickets here. -->
<!-- Say "Closes #0" for issues that the PR resolves, replacing 0 with the issue number. -->
Closes #402

## Description
<!-- Describe how you've implemented your changes. --> 
This PR adds proper fallback messages when the halloweenify command is invoked by a member staff or through DM.

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
The bot doesn't have enough rights to modify staff nicknames, and can't change it when it is invoked through DM neither.


## Screenshots
<!-- Remove this section if the changes don't impact anything user-facing. -->
<!-- You can add images by just copy pasting them directly in the editor. -->
![image](https://user-images.githubusercontent.com/44778521/80981663-92bf4280-8e2a-11ea-8c05-4a889b9a43b3.png)
In-server usage.

![image](https://user-images.githubusercontent.com/44778521/80981709-a23e8b80-8e2a-11ea-8615-41442ec07627.png)
Staff uage.

![image](https://user-images.githubusercontent.com/44778521/80981747-ab2f5d00-8e2a-11ea-9256-0ff77acff9c2.png)
In DM usage.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X] If dependencies have been added or updated, run `pipenv lock`?
- [X] **Lint your code** (`pipenv run lint`)?
- [X] Set the PR to **allow edits from contributors**?
