### PR TITLE
Show bot prefix in rich presence

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -203,4 +203,7 @@ class SeasonalBot(commands.Bot):
         await self._guild_available.wait()
 
 
-bot = SeasonalBot(command_prefix=Client.prefix)
+bot = SeasonalBot(
+    command_prefix=Client.prefix,
+    activity=discord.Game(name=f"Commands: {Client.prefix}help"),
+)


### PR DESCRIPTION
Closes #404 

This will hint users at the help command, while also showing what the prefix for SeasonalBot is. We emulate the main bot's message for the sake of consistency:

![image](https://user-images.githubusercontent.com/44734341/81439884-662f6180-916f-11ea-9e3e-45e24da74bfc.png)
