### PR TITLE
Set ayncio event loop to Selector on windows.

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import logging.handlers
 import os
@@ -63,3 +64,8 @@ logging.basicConfig(
     handlers=[console_handler, file_handler]
 )
 logging.getLogger().info('Logging initialization complete')
+
+
+# On Windows, the selector event loop is required for aiodns.
+if os.name == "nt":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
## Relevant Issues
Fixes #409 

## Description
Sets the event loop to Selector to prevent bot crashes on windows when an aiohttp request is made, as described in #409 
Same implementation as in https://github.com/python-discord/bot/pull/903
