### PR TITLE
Encoding bug fix

### DIFF
--- a/bot/exts/christmas/adventofcode.py
+++ b/bot/exts/christmas/adventofcode.py
@@ -429,7 +429,7 @@ class AdventOfCode(commands.Cog):
 
     def _build_about_embed(self) -> discord.Embed:
         """Build and return the informational "About AoC" embed from the resources file."""
-        with self.about_aoc_filepath.open("r") as f:
+        with self.about_aoc_filepath.open("r", encoding="utf8") as f:
             embed_fields = json.load(f)
 
         about_embed = discord.Embed(title=self._base_url, colour=Colours.soft_green, url=self._base_url)

--- a/bot/exts/easter/april_fools_vids.py
+++ b/bot/exts/easter/april_fools_vids.py
@@ -20,7 +20,7 @@ class AprilFoolVideos(commands.Cog):
     def load_json() -> dict:
         """A function to load JSON data."""
         p = Path('bot/resources/easter/april_fools_vids.json')
-        with p.open() as json_file:
+        with p.open(encoding="utf-8") as json_file:
             all_vids = load(json_file)
         return all_vids
 

--- a/bot/exts/easter/egg_decorating.py
+++ b/bot/exts/easter/egg_decorating.py
@@ -12,10 +12,10 @@ from discord.ext import commands
 
 log = logging.getLogger(__name__)
 
-with open(Path("bot/resources/evergreen/html_colours.json")) as f:
+with open(Path("bot/resources/evergreen/html_colours.json"), encoding="utf8") as f:
     HTML_COLOURS = json.load(f)
 
-with open(Path("bot/resources/evergreen/xkcd_colours.json")) as f:
+with open(Path("bot/resources/evergreen/xkcd_colours.json"), encoding="utf8") as f:
     XKCD_COLOURS = json.load(f)
 
 COLOURS = [

--- a/bot/exts/evergreen/branding.py
+++ b/bot/exts/evergreen/branding.py
@@ -179,7 +179,7 @@ class BrandingManager(commands.Cog):
         current_config = self._read_config()
         current_config[key] = value
 
-        with self.config_file.open("w") as persistent_file:
+        with self.config_file.open("w", encoding="utf8") as persistent_file:
             json.dump(current_config, persistent_file)
 
     async def _daemon_func(self) -> None:

--- a/bot/exts/evergreen/branding.py
+++ b/bot/exts/evergreen/branding.py
@@ -171,7 +171,7 @@ class BrandingManager(commands.Cog):
 
     def _read_config(self) -> t.Dict[str, bool]:
         """Read and return persistent config file."""
-        with self.config_file.open("r") as persistent_file:
+        with self.config_file.open("r", encoding="utf8") as persistent_file:
             return json.load(persistent_file)
 
     def _write_config(self, key: str, value: bool) -> None:

--- a/bot/exts/evergreen/magic_8ball.py
+++ b/bot/exts/evergreen/magic_8ball.py
@@ -13,7 +13,7 @@ class Magic8ball(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        with open(Path("bot/resources/evergreen/magic8ball.json"), "r") as file:
+        with open(Path("bot/resources/evergreen/magic8ball.json"), "r", encoding="utf8") as file:
             self.answers = json.load(file)
 
     @commands.command(name="8ball")

--- a/bot/exts/evergreen/recommend_game.py
+++ b/bot/exts/evergreen/recommend_game.py
@@ -11,7 +11,7 @@ game_recs = []
 
 # Populate the list `game_recs` with resource files
 for rec_path in Path("bot/resources/evergreen/game_recs").glob("*.json"):
-    with rec_path.open(encoding='utf-8') as file:
+    with rec_path.open(encoding='utf8') as file:
         data = json.load(file)
     game_recs.append(data)
 shuffle(game_recs)

--- a/bot/exts/evergreen/snakes/converter.py
+++ b/bot/exts/evergreen/snakes/converter.py
@@ -63,12 +63,12 @@ class Snake(Converter):
         """Build list of snakes from the static snake resources."""
         # Get all the snakes
         if cls.snakes is None:
-            with (SNAKE_RESOURCES / "snake_names.json").open() as snakefile:
+            with (SNAKE_RESOURCES / "snake_names.json").open(encoding="utf8") as snakefile:
                 cls.snakes = json.load(snakefile)
 
         # Get the special cases
         if cls.special_cases is None:
-            with (SNAKE_RESOURCES / "special_snakes.json").open() as snakefile:
+            with (SNAKE_RESOURCES / "special_snakes.json").open(encoding="utf8") as snakefile:
                 special_cases = json.load(snakefile)
             cls.special_cases = {snake['name'].lower(): snake for snake in special_cases}
 

--- a/bot/exts/evergreen/speedrun.py
+++ b/bot/exts/evergreen/speedrun.py
@@ -6,7 +6,7 @@ from random import choice
 from discord.ext import commands
 
 log = logging.getLogger(__name__)
-with Path('bot/resources/evergreen/speedrun_links.json').open(encoding="utf-8") as file:
+with Path('bot/resources/evergreen/speedrun_links.json').open(encoding="utf8") as file:
     LINKS = json.load(file)
 
 

--- a/bot/exts/evergreen/trivia_quiz.py
+++ b/bot/exts/evergreen/trivia_quiz.py
@@ -40,7 +40,7 @@ class TriviaQuiz(commands.Cog):
     def load_questions() -> dict:
         """Load the questions from the JSON file."""
         p = Path("bot", "resources", "evergreen", "trivia_quiz.json")
-        with p.open(encoding="utf-8") as json_data:
+        with p.open(encoding="utf8") as json_data:
             questions = json.load(json_data)
             return questions
 

--- a/bot/exts/evergreen/trivia_quiz.py
+++ b/bot/exts/evergreen/trivia_quiz.py
@@ -40,7 +40,7 @@ class TriviaQuiz(commands.Cog):
     def load_questions() -> dict:
         """Load the questions from the JSON file."""
         p = Path("bot", "resources", "evergreen", "trivia_quiz.json")
-        with p.open() as json_data:
+        with p.open(encoding="utf-8") as json_data:
             questions = json.load(json_data)
             return questions
 

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -178,7 +178,7 @@ class CandyCollection(commands.Cog):
 
     def save_to_json(self) -> None:
         """Save JSON to a local file."""
-        with open(json_location, 'w') as outfile:
+        with open(json_location, 'w', encoding="utf8") as outfile:
             json.dump(self.candy_json, outfile)
 
     @in_month(Month.OCTOBER)

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -27,7 +27,7 @@ class CandyCollection(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        with open(json_location) as candy:
+        with open(json_location, encoding="utf8") as candy:
             self.candy_json = json.load(candy)
             self.msg_reacted = self.candy_json['msg_reacted']
         self.get_candyinfo = dict()

--- a/bot/exts/halloween/hacktoberstats.py
+++ b/bot/exts/halloween/hacktoberstats.py
@@ -145,7 +145,7 @@ class HacktoberStats(commands.Cog):
             }
         """
         logging.info(f"Saving linked_accounts to '{self.link_json}'")
-        with open(self.link_json, 'w') as file:
+        with open(self.link_json, 'w', encoding="utf8") as file:
             json.dump(self.linked_accounts, file, default=str)
         logging.info(f"linked_accounts saved to '{self.link_json}'")
 

--- a/bot/exts/halloween/hacktoberstats.py
+++ b/bot/exts/halloween/hacktoberstats.py
@@ -123,7 +123,7 @@ class HacktoberStats(commands.Cog):
         """
         if self.link_json.exists():
             logging.info(f"Loading linked GitHub accounts from '{self.link_json}'")
-            with open(self.link_json, 'r') as file:
+            with open(self.link_json, 'r', encoding="utf8") as file:
                 linked_accounts = json.load(file)
 
             logging.info(f"Loaded {len(linked_accounts)} linked GitHub accounts from '{self.link_json}'")

--- a/bot/exts/halloween/halloween_facts.py
+++ b/bot/exts/halloween/halloween_facts.py
@@ -29,7 +29,7 @@ class HalloweenFacts(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        with open(Path("bot/resources/halloween/halloween_facts.json"), "r") as file:
+        with open(Path("bot/resources/halloween/halloween_facts.json"), "r", encoding="utf8") as file:
             self.halloween_facts = json.load(file)
         self.facts = list(enumerate(self.halloween_facts))
         random.shuffle(self.facts)

--- a/bot/exts/halloween/halloweenify.py
+++ b/bot/exts/halloween/halloweenify.py
@@ -21,7 +21,7 @@ class Halloweenify(commands.Cog):
     async def halloweenify(self, ctx: commands.Context) -> None:
         """Change your nickname into a much spookier one!"""
         async with ctx.typing():
-            with open(Path("bot/resources/halloween/halloweenify.json"), "r") as f:
+            with open(Path("bot/resources/halloween/halloweenify.json"), "r", encoding="utf8") as f:
                 data = load(f)
 
             # Choose a random character from our list we loaded above and set apart the nickname and image url.

--- a/bot/exts/halloween/monstersurvey.py
+++ b/bot/exts/halloween/monstersurvey.py
@@ -27,7 +27,7 @@ class MonsterSurvey(Cog):
         """Initializes values for the bot to use within the voting commands."""
         self.bot = bot
         self.registry_location = os.path.join(os.getcwd(), 'bot', 'resources', 'halloween', 'monstersurvey.json')
-        with open(self.registry_location, 'r') as jason:
+        with open(self.registry_location, 'r', encoding="utf8") as jason:
             self.voter_registry = json.load(jason)
 
     def json_write(self) -> None:

--- a/bot/exts/halloween/monstersurvey.py
+++ b/bot/exts/halloween/monstersurvey.py
@@ -33,7 +33,7 @@ class MonsterSurvey(Cog):
     def json_write(self) -> None:
         """Write voting results to a local JSON file."""
         log.info("Saved Monster Survey Results")
-        with open(self.registry_location, 'w') as jason:
+        with open(self.registry_location, 'w', encoding="utf8") as jason:
             json.dump(self.voter_registry, jason, indent=2)
 
     def cast_vote(self, id: int, monster: str) -> None:

--- a/bot/exts/halloween/spookyrating.py
+++ b/bot/exts/halloween/spookyrating.py
@@ -11,7 +11,7 @@ from bot.constants import Colours
 
 log = logging.getLogger(__name__)
 
-with Path("bot/resources/halloween/spooky_rating.json").open() as file:
+with Path("bot/resources/halloween/spooky_rating.json").open(encoding="utf8") as file:
     SPOOKY_DATA = json.load(file)
     SPOOKY_DATA = sorted((int(key), value) for key, value in SPOOKY_DATA.items())
 

--- a/bot/exts/pride/drag_queen_name.py
+++ b/bot/exts/pride/drag_queen_name.py
@@ -18,7 +18,7 @@ class DragNames(commands.Cog):
     @staticmethod
     def load_names() -> list:
         """Loads a list of drag queen names."""
-        with open(Path("bot/resources/pride/drag_queen_names.json"), "r", encoding="utf-8") as f:
+        with open(Path("bot/resources/pride/drag_queen_names.json"), "r", encoding="utf8") as f:
             return json.load(f)
 
     @commands.command(name="dragname", aliases=["dragqueenname", "queenme"])

--- a/bot/exts/pride/pride_anthem.py
+++ b/bot/exts/pride/pride_anthem.py
@@ -34,7 +34,7 @@ class PrideAnthem(commands.Cog):
     @staticmethod
     def load_vids() -> list:
         """Loads a list of videos from the resources folder as dictionaries."""
-        with open(Path("bot/resources/pride/anthems.json"), "r", encoding="utf-8") as f:
+        with open(Path("bot/resources/pride/anthems.json"), "r", encoding="utf8") as f:
             anthems = json.load(f)
         return anthems
 

--- a/bot/exts/pride/pride_facts.py
+++ b/bot/exts/pride/pride_facts.py
@@ -30,7 +30,7 @@ class PrideFacts(commands.Cog):
     @staticmethod
     def load_facts() -> dict:
         """Loads a dictionary of years mapping to lists of facts."""
-        with open(Path("bot/resources/pride/facts.json"), "r", encoding="utf-8") as f:
+        with open(Path("bot/resources/pride/facts.json"), "r", encoding="utf8") as f:
             return json.load(f)
 
     @seasonal_task(Month.JUNE)

--- a/bot/exts/valentines/be_my_valentine.py
+++ b/bot/exts/valentines/be_my_valentine.py
@@ -27,7 +27,7 @@ class BeMyValentine(commands.Cog):
     def load_json() -> dict:
         """Load Valentines messages from the static resources."""
         p = Path("bot/resources/valentines/bemyvalentine_valentines.json")
-        with p.open() as json_data:
+        with p.open(encoding="utf8") as json_data:
             valentines = load(json_data)
             return valentines
 

--- a/bot/exts/valentines/lovecalculator.py
+++ b/bot/exts/valentines/lovecalculator.py
@@ -15,7 +15,7 @@ from bot.constants import Roles
 
 log = logging.getLogger(__name__)
 
-with Path("bot/resources/valentines/love_matches.json").open() as file:
+with Path("bot/resources/valentines/love_matches.json").open(encoding="utf8") as file:
     LOVE_DATA = json.load(file)
     LOVE_DATA = sorted((int(key), value) for key, value in LOVE_DATA.items())
 

--- a/bot/exts/valentines/myvalenstate.py
+++ b/bot/exts/valentines/myvalenstate.py
@@ -11,7 +11,7 @@ from bot.constants import Colours
 
 log = logging.getLogger(__name__)
 
-with open(Path("bot/resources/valentines/valenstates.json"), "r") as file:
+with open(Path("bot/resources/valentines/valenstates.json"), "r", encoding="utf8") as file:
     STATES = json.load(file)
 
 

--- a/bot/exts/valentines/valentine_zodiac.py
+++ b/bot/exts/valentines/valentine_zodiac.py
@@ -25,7 +25,7 @@ class ValentineZodiac(commands.Cog):
     def load_json() -> dict:
         """Load zodiac compatibility from static JSON resource."""
         p = Path("bot/resources/valentines/zodiac_compatibility.json")
-        with p.open() as json_data:
+        with p.open(encoding="utf8") as json_data:
             zodiacs = load(json_data)
             return zodiacs
 

--- a/bot/exts/valentines/whoisvalentine.py
+++ b/bot/exts/valentines/whoisvalentine.py
@@ -10,7 +10,7 @@ from bot.constants import Colours
 
 log = logging.getLogger(__name__)
 
-with open(Path("bot/resources/valentines/valentine_facts.json"), "r") as file:
+with open(Path("bot/resources/valentines/valentine_facts.json"), "r", encoding="utf8") as file:
     FACTS = json.load(file)
 
 

--- a/bot/utils/persist.py
+++ b/bot/utils/persist.py
@@ -25,7 +25,7 @@ def make_persistent(file_path: Path) -> Path:
     as otherwise only one datafile can be persistent and will be returned for
     both cases.
 
-    Ensure that all open files are using explicit appropriate encoding to avoid encod
+    Ensure that all open files are using explicit appropriate encoding to avoid
     encoding errors from diffent OS systems.
 
     Example Usage:

--- a/bot/utils/persist.py
+++ b/bot/utils/persist.py
@@ -25,13 +25,16 @@ def make_persistent(file_path: Path) -> Path:
     as otherwise only one datafile can be persistent and will be returned for
     both cases.
 
+    Ensure that all open files are using explicit appropriate encoding to avoid encod
+    encoding errors from diffent OS systems.
+
     Example Usage:
     >>> import json
     >>> template_datafile = Path("bot", "resources", "evergreen", "myfile.json")
     >>> path_to_persistent_file = make_persistent(template_datafile)
     >>> print(path_to_persistent_file)
     data/evergreen/myfile.json
-    >>> with path_to_persistent_file.open("w+") as f:
+    >>> with path_to_persistent_file.open("w+", encoding="utf8") as f:
     >>>     data = json.load(f)
     """
     # ensure the persistent data directory exists


### PR DESCRIPTION
## Relevant Issues
- Cleanup: Add explicit encoding on open() calls #334
- Files without an encoding specified may crash bot #411

Closes #334 
Closes #411 

## Description
Added explicit encoding to `utf8` for cogs that open json or other text files.


## Reasoning
Though this did not cause errors in Unix based OS, it was causing errors when loading some of those files in windows OS.


## Additional Details
We may require explicit encoding going forward for other cogs being added to the bots that needs to read in a file.


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
