### PR TITLE
Created the statuscat command.

### DIFF
--- a/bot/exts/evergreen/status_cats.py
+++ b/bot/exts/evergreen/status_cats.py
@@ -1,10 +1,7 @@
-import logging
 from http import HTTPStatus
 
 import discord
 from discord.ext import commands
-
-log = logging.getLogger(__name__)
 
 
 class StatusCats(commands.Cog):
@@ -20,12 +17,15 @@ class StatusCats(commands.Cog):
 
         try:
             HTTPStatus(code)
-            embed.set_image(url=f'https://http.cat/{code}.jpg')
 
         except ValueError:
             embed.set_footer(text='Inputted status code does not exist.')
 
-        await ctx.send(embed=embed)
+        else:
+            embed.set_image(url=f'https://http.cat/{code}.jpg')
+
+        finally:
+            await ctx.send(embed=embed)
 
 
 def setup(bot: commands.Bot) -> None:

--- a/bot/exts/evergreen/status_cats.py
+++ b/bot/exts/evergreen/status_cats.py
@@ -18,7 +18,6 @@ class StatusCats(commands.Cog):
         """Sends an embed with an image of a cat, potraying the status code."""
         embed = discord.Embed(title=f'**Status: {code}**')
 
-
         try:
             HTTPStatus(code)
             embed.set_image(url=f'https://http.cat/{code}.jpg')

--- a/bot/exts/evergreen/status_cats.py
+++ b/bot/exts/evergreen/status_cats.py
@@ -1,0 +1,33 @@
+import logging
+
+from discord.ext import commands
+from http import HTTPStatus
+import discord
+
+log = logging.getLogger(__name__)
+
+
+class StatusCats(commands.Cog):
+    """Commands that give statuses described and visualized by cats."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command(aliases=['statuscat'])
+    async def http_cat(self, ctx, code: int) -> None:
+        """Sends an embed with an image of a cat, potraying the status code."""
+        embed = discord.Embed(title=f'**Status: {code}**')
+        embed.set_image(url=f'https://http.cat/{code}.jpg')
+
+        try:
+            HTTPStatus(code)
+
+        except ValueError:
+            embed.set_footer(text='Inputted status code does not exist.')
+
+        await ctx.send(embed=embed)
+
+
+def setup(bot: commands.Bot) -> None:
+    """Load the StatusCats cog."""
+    bot.add_cog(StatusCats(bot))

--- a/bot/exts/evergreen/status_cats.py
+++ b/bot/exts/evergreen/status_cats.py
@@ -17,10 +17,11 @@ class StatusCats(commands.Cog):
     async def http_cat(self, ctx: commands.Context, code: int) -> None:
         """Sends an embed with an image of a cat, potraying the status code."""
         embed = discord.Embed(title=f'**Status: {code}**')
-        embed.set_image(url=f'https://http.cat/{code}.jpg')
+
 
         try:
             HTTPStatus(code)
+            embed.set_image(url=f'https://http.cat/{code}.jpg')
 
         except ValueError:
             embed.set_footer(text='Inputted status code does not exist.')

--- a/bot/exts/evergreen/status_cats.py
+++ b/bot/exts/evergreen/status_cats.py
@@ -1,8 +1,8 @@
 import logging
-
-from discord.ext import commands
 from http import HTTPStatus
+
 import discord
+from discord.ext import commands
 
 log = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ class StatusCats(commands.Cog):
         self.bot = bot
 
     @commands.command(aliases=['statuscat'])
-    async def http_cat(self, ctx, code: int) -> None:
+    async def http_cat(self, ctx: commands.Context, code: int) -> None:
         """Sends an embed with an image of a cat, potraying the status code."""
         embed = discord.Embed(title=f'**Status: {code}**')
         embed.set_image(url=f'https://http.cat/{code}.jpg')

--- a/bot/exts/evergreen/status_cats.py
+++ b/bot/exts/evergreen/status_cats.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 
 class StatusCats(commands.Cog):
-    """Commands that give statuses described and visualized by cats."""
+    """Commands that give HTTP statuses described and visualized by cats."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot


### PR DESCRIPTION
## Relevant Issues
<!-- List relevant issue tickets here. -->
<!-- Say "Closes #0" for issues that the PR resolves, replacing 0 with the issue number. -->
Closes #423 

## Description
<!-- Describe how you've implemented your changes. -->
I've added a command called `"http_cat"` with an alias `"statuscat"`. It recieves an integer from a user, then processes it through `http.HTTPStatus` to see if the status code actually exists. If it does, the URL will be valid and a picture will be displayed within an embed. If not, the embed won't show an image and instead it will tell you that the status code provided does not exist.

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
Instead of using `aiohttp` with a `ClientSession` to get information from the URL, I simply used the URL as the image within the embed.

## Screenshots
<!-- Remove this section if the changes don't impact anything user-facing. -->
<!-- You can add images by just copy pasting them directly in the editor. -->
![image](https://user-images.githubusercontent.com/15021300/87229769-e0db4f80-c35f-11ea-830c-937fb1a44cda.png)


## Additional notes:
When using a browser you can type in any code or string into the `code` section of the f-string `embed.set_image(url=f'https://http.cat/{code}.jpg')` and it will give you a 404 image. For whatever reason the image will not be put into the embed. Setting `code` to 404 will work, though.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
