### PR TITLE
Stop users from viewing messages they shouldn't.

### DIFF
--- a/bot/exts/evergreen/fun.py
+++ b/bot/exts/evergreen/fun.py
@@ -181,18 +181,22 @@ class Fun(Cog):
         """
         Attempts to extract the text and embed from a possible link to a discord Message.
 
+        Does not retrieve the text and embed from the Message if it is in a channel the user does
+        not have read permissions in.
+
         Returns a tuple of:
             str: If `text` is a valid discord Message, the contents of the message, else `text`.
             Union[Embed, None]: The embed if found in the valid Message, else None
         """
         embed = None
 
-        # message = await Fun._get_discord_message(ctx, text)
-        # if isinstance(message, Message):
-        #     text = message.content
-        #     # Take first embed because we can't send multiple embeds
-        #     if message.embeds:
-        #         embed = message.embeds[0]
+        msg = await Fun._get_discord_message(ctx, text)
+        # Ensure the user has read permissions for the channel the message is in
+        if isinstance(msg, Message) and ctx.author.permissions_in(msg.channel).read_messages:
+            text = msg.content
+            # Take first embed because we can't send multiple embeds
+            if msg.embeds:
+                embed = msg.embeds[0]
 
         return (text, embed)
 


### PR DESCRIPTION
Using a user token, a user could fetch the message ID of a message in any channel, which may leak information when potential Message objects are automatically converted and parsed.

Now, the bot will only retrive text from a valid Message object if the user has read permissions for the message the channel is in.

![image](https://user-images.githubusercontent.com/41782385/93617456-9386f880-fa08-11ea-98c4-023cd764a9ef.png)

