### PR TITLE
Prevent uwu output from pinging globally allowed roles.

### DIFF
--- a/bot/exts/evergreen/fun.py
+++ b/bot/exts/evergreen/fun.py
@@ -5,7 +5,7 @@ from typing import Callable, Tuple, Union
 
 from discord import Embed, Message
 from discord.ext import commands
-from discord.ext.commands import Bot, Cog, Context, MessageConverter
+from discord.ext.commands import Bot, Cog, Context, MessageConverter, clean_content
 
 from bot import utils
 from bot.constants import Emojis
@@ -46,7 +46,7 @@ class Fun(Cog):
         await ctx.send(output)
 
     @commands.command(name="uwu", aliases=("uwuwize", "uwuify",))
-    async def uwu_command(self, ctx: Context, *, text: str) -> None:
+    async def uwu_command(self, ctx: Context, *, text: clean_content(fix_channel_mentions=True)) -> None:
         """Converts a given `text` into it's uwu equivalent."""
         conversion_func = functools.partial(
             utils.replace_many, replacements=UWU_WORDS, ignore_case=True, match_case=True

--- a/bot/exts/evergreen/fun.py
+++ b/bot/exts/evergreen/fun.py
@@ -87,7 +87,7 @@ class Fun(Cog):
         await ctx.send(content=converted_text, embed=embed)
 
     @commands.command(name="randomcase", aliases=("rcase", "randomcaps", "rcaps",))
-    async def randomcase_command(self, ctx: Context, *, text: str) -> None:
+    async def randomcase_command(self, ctx: Context, *, text: clean_content(fix_channel_mentions=True)) -> None:
         """Randomly converts the casing of a given `text`."""
         def conversion_func(text: str) -> str:
             """Randomly converts the casing of a given string."""
@@ -193,7 +193,7 @@ class Fun(Cog):
         msg = await Fun._get_discord_message(ctx, text)
         # Ensure the user has read permissions for the channel the message is in
         if isinstance(msg, Message) and ctx.author.permissions_in(msg.channel).read_messages:
-            text = msg.content
+            text = msg.clean_content
             # Take first embed because we can't send multiple embeds
             if msg.embeds:
                 embed = msg.embeds[0]


### PR DESCRIPTION
Description
<!-- Describe how you've implemented your changes. -->
This PR introduces sanitisation of the uwu text before uwufication in order to prevent moderator roles being pinged unnecessarily.

I've just changed the `str` typehint to the `clean_content` converter to do this as simply as possible.

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
While we do have a global limit to allowed roles being pinged in the bot, all mod+ roles were still capable of being pinged through this method.

## Screenshots
<!-- Remove this section if the changes don't impact anything user-facing. -->
<!-- You can add images by just copy pasting them directly in the editor. -->
**Before** (role resolves)
![image](https://user-images.githubusercontent.com/29337040/93747070-80a73a80-fc39-11ea-96bc-f4d039941b3d.png)

**After** (role is now plaintext)
![image](https://user-images.githubusercontent.com/29337040/93747114-93ba0a80-fc39-11ea-8f68-20cec150d6ef.png)

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [X] Join the [**Python Discord Community**](https://discord.gg/python)?
- [X] If dependencies have been added or updated, run `pipenv lock`?
- [X] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
