### PR TITLE
Hacktoberfest fixes

### DIFF
--- a/bot/exts/halloween/hacktoberstats.py
+++ b/bot/exts/halloween/hacktoberstats.py
@@ -196,7 +196,7 @@ class HacktoberStats(commands.Cog):
         stats_embed.set_author(
             name="Hacktoberfest",
             url="https://hacktoberfest.digitalocean.com",
-            icon_url="https://hacktoberfest.digitalocean.com/pretty_logo.png"
+            icon_url="https://avatars1.githubusercontent.com/u/35706162?s=200&v=4"
         )
         stats_embed.add_field(
             name="Top 5 Repositories:",

--- a/bot/exts/halloween/hacktoberstats.py
+++ b/bot/exts/halloween/hacktoberstats.py
@@ -29,7 +29,7 @@ class HacktoberStats(commands.Cog):
         self.link_json = make_persistent(Path("bot", "resources", "halloween", "github_links.json"))
         self.linked_accounts = self.load_linked_users()
 
-    @in_month(Month.OCTOBER)
+    @in_month(Month.SEPTEMBER, Month.OCTOBER, Month.NOVEMBER)
     @commands.group(name="hacktoberstats", aliases=("hackstats",), invoke_without_command=True)
     @override_in_channel(HACKTOBER_WHITELIST)
     async def hacktoberstats_group(self, ctx: commands.Context, github_username: str = None) -> None:
@@ -57,7 +57,7 @@ class HacktoberStats(commands.Cog):
 
         await self.get_stats(ctx, github_username)
 
-    @in_month(Month.OCTOBER)
+    @in_month(Month.SEPTEMBER, Month.OCTOBER, Month.NOVEMBER)
     @hacktoberstats_group.command(name="link")
     @override_in_channel(HACKTOBER_WHITELIST)
     async def link_user(self, ctx: commands.Context, github_username: str = None) -> None:
@@ -92,7 +92,7 @@ class HacktoberStats(commands.Cog):
             logging.info(f"{author_id} tried to link a GitHub account but didn't provide a username")
             await ctx.send(f"{author_mention}, a GitHub username is required to link your account")
 
-    @in_month(Month.OCTOBER)
+    @in_month(Month.SEPTEMBER, Month.OCTOBER, Month.NOVEMBER)
     @hacktoberstats_group.command(name="unlink")
     @override_in_channel(HACKTOBER_WHITELIST)
     async def unlink_user(self, ctx: commands.Context) -> None:

--- a/bot/exts/halloween/hacktoberstats.py
+++ b/bot/exts/halloween/hacktoberstats.py
@@ -175,11 +175,11 @@ class HacktoberStats(commands.Cog):
 
         n = pr_stats['n_prs']
         if n >= PRS_FOR_SHIRT:
-            shirtstr = f"**{github_username} has earned a tshirt!**"
+            shirtstr = f"**{github_username} has earned a T-shirt or a tree!**"
         elif n == PRS_FOR_SHIRT - 1:
-            shirtstr = f"**{github_username} is 1 PR away from a tshirt!**"
+            shirtstr = f"**{github_username} is 1 PR away from a T-shirt or a tree!**"
         else:
-            shirtstr = f"**{github_username} is {PRS_FOR_SHIRT - n} PRs away from a tshirt!**"
+            shirtstr = f"**{github_username} is {PRS_FOR_SHIRT - n} PRs away from a T-shirt or a tree!**"
 
         stats_embed = discord.Embed(
             title=f"{github_username}'s Hacktoberfest",

--- a/bot/exts/halloween/timeleft.py
+++ b/bot/exts/halloween/timeleft.py
@@ -13,20 +13,23 @@ class TimeLeft(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
-    @staticmethod
-    def in_october() -> bool:
-        """Return True if the current month is October."""
-        return datetime.utcnow().month == 10
+    def in_hacktober(self) -> bool:
+        """Return True if the current time is within Hacktoberfest."""
+        _, end, start = self.load_date()
+
+        now = datetime.utcnow()
+
+        return start <= now <= end
 
     @staticmethod
-    def load_date() -> Tuple[int, datetime, datetime]:
+    def load_date() -> Tuple[datetime, datetime, datetime]:
         """Return of a tuple of the current time and the end and start times of the next October."""
         now = datetime.utcnow()
         year = now.year
         if now.month > 10:
             year += 1
-        end = datetime(year, 11, 1, 11, 59, 59)
-        start = datetime(year, 10, 1)
+        end = datetime(year, 11, 1, 12)  # November 1st 12:00 (UTC-12:00)
+        start = datetime(year, 9, 30, 10)  # September 30th 10:00 (UTC+14:00)
         return now, end, start
 
     @commands.command()
@@ -35,16 +38,20 @@ class TimeLeft(commands.Cog):
         Calculates the time left until the end of Hacktober.
 
         Whilst in October, displays the days, hours and minutes left.
-        Only displays the days left until the beginning and end whilst in a different month
+        Only displays the days left until the beginning and end whilst in a different month.
+
+        This factors in that Hacktoberfest starts when it is October anywhere in the world
+        and ends with the same rules. It treats the start as UTC+14:00 and the end as
+        UTC-12.
         """
         now, end, start = self.load_date()
         diff = end - now
         days, seconds = diff.days, diff.seconds
-        if self.in_october():
+        if self.in_hacktober():
             minutes = seconds // 60
             hours, minutes = divmod(minutes, 60)
-            await ctx.send(f"There is currently only {days} days, {hours} hours and {minutes}"
-                           "minutes left until the end of Hacktober.")
+            await ctx.send(f"There are {days} days, {hours} hours and {minutes}"
+                           " minutes left until the end of Hacktober.")
         else:
             start_diff = start - now
             start_days = start_diff.days

--- a/bot/exts/halloween/timeleft.py
+++ b/bot/exts/halloween/timeleft.py
@@ -50,8 +50,11 @@ class TimeLeft(commands.Cog):
         if self.in_hacktober():
             minutes = seconds // 60
             hours, minutes = divmod(minutes, 60)
-            await ctx.send(f"There are {days} days, {hours} hours and {minutes}"
-                           " minutes left until the end of Hacktober.")
+
+            await ctx.send(
+                f"There are {days} days, {hours} hours and {minutes}"
+                f" minutes left until the end of Hacktober."
+            )
         else:
             start_diff = start - now
             start_days = start_diff.days


### PR DESCRIPTION
## Description
This PR fixes a set of issues with the Hacktoberfest commands.

- It allows the commands to be used in September and November so that the early start and late finish (Hacktoberfest starts and ends where it is October anywhere in the world) are factored in. This is also relevant because Hacktober now uses September as "Pre-temper" where maintainers should get issues ready.
- Updates the Hacktoberfest command branding to 2020
- References that you can also plant a tree
- Updates the timeleft command to use the Hacktoberfest dates, not just the month of October.

## Screenshots
![image](https://user-images.githubusercontent.com/20439493/94742488-a933e080-036d-11eb-8552-c8b1d510aa2d.png)

![image](https://user-images.githubusercontent.com/20439493/94743596-8dc9d500-036f-11eb-875a-8d24c9f84627.png)


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [ ] ~~If dependencies have been added or updated, run `pipenv lock`?~~
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
