### PR TITLE
Hacktoberfest Stats: Check GitHub user exists before searching for PRs

### DIFF
--- a/bot/exts/halloween/hacktoberstats.py
+++ b/bot/exts/halloween/hacktoberstats.py
@@ -10,7 +10,7 @@ import aiohttp
 import discord
 from discord.ext import commands
 
-from bot.constants import Channels, Month, WHITELISTED_CHANNELS
+from bot.constants import Channels, Month, Tokens, WHITELISTED_CHANNELS
 from bot.utils.decorators import in_month, override_in_channel
 from bot.utils.persist import make_persistent
 
@@ -19,6 +19,10 @@ log = logging.getLogger(__name__)
 CURRENT_YEAR = datetime.now().year  # Used to construct GH API query
 PRS_FOR_SHIRT = 4  # Minimum number of PRs before a shirt is awarded
 HACKTOBER_WHITELIST = WHITELISTED_CHANNELS + (Channels.hacktoberfest_2020,)
+
+REQUEST_HEADERS = {"User-Agent": "Python Discord Hacktoberbot"}
+if GITHUB_TOKEN := Tokens.github:
+    REQUEST_HEADERS["Authorization"] = f"token {GITHUB_TOKEN}"
 
 
 class HacktoberStats(commands.Cog):
@@ -242,9 +246,8 @@ class HacktoberStats(commands.Cog):
             f"&per_page={per_page}"
         )
 
-        headers = {"user-agent": "Discord Python Hacktoberbot"}
         async with aiohttp.ClientSession() as session:
-            async with session.get(query_url, headers=headers) as resp:
+            async with session.get(query_url, headers=REQUEST_HEADERS) as resp:
                 jsonresp = await resp.json()
 
         if "message" in jsonresp.keys():

--- a/bot/exts/halloween/hacktoberstats.py
+++ b/bot/exts/halloween/hacktoberstats.py
@@ -247,6 +247,11 @@ class HacktoberStats(commands.Cog):
         )
 
         async with aiohttp.ClientSession() as session:
+            async with session.get(f"https://api.github.com/users/{github_username}", headers=REQUEST_HEADERS) as resp:
+                if resp.status == 404:
+                    logging.debug(f"No GitHub user found named '{github_username}'")
+                    return
+
             async with session.get(query_url, headers=REQUEST_HEADERS) as resp:
                 jsonresp = await resp.json()
 


### PR DESCRIPTION
## Description
The `.hackstats` command logs an error when a given username does not exist on GitHub. This is not an actual issue, so we want to avoid logging this as an error. To prevent this, we should check the user exists before searching for their PRs.

I've also added authentication to the GitHub API requests in this cog and slightly changed the user agent.

Closes #467.
