### PR TITLE
Add space between dice in roll command

### DIFF
--- a/bot/exts/evergreen/fun.py
+++ b/bot/exts/evergreen/fun.py
@@ -7,7 +7,7 @@ from typing import Callable, Iterable, Tuple, Union
 
 from discord import Embed, Message
 from discord.ext import commands
-from discord.ext.commands import Bot, Cog, Context, MessageConverter, clean_content
+from discord.ext.commands import BadArgument, Bot, Cog, Context, MessageConverter, clean_content
 
 from bot import utils
 from bot.constants import Colours, Emojis
@@ -60,15 +60,17 @@ class Fun(Cog):
     @commands.command()
     async def roll(self, ctx: Context, num_rolls: int = 1) -> None:
         """Outputs a number of random dice emotes (up to 6)."""
-        output = ""
-        if num_rolls > 6:
-            num_rolls = 6
-        elif num_rolls < 1:
-            output = ":no_entry: You must roll at least once."
-        for _ in range(num_rolls):
-            dice = f"dice_{random.randint(1, 6)}"
-            output += getattr(Emojis, dice, '') + " "
-        await ctx.send(output.rstrip())
+        def _get_random_die() -> str:
+            """Generate a random die emoji, ready to be sent on Discord."""
+            die_name = f"dice_{random.randint(1, 6)}"
+            return getattr(Emojis, die_name)
+
+        # Only support between 1 and 6 rolls
+        if 1 <= num_rolls <= 6:
+            dice = " ".join(_get_random_die() for _ in range(num_rolls))
+            await ctx.send(dice)
+        else:
+            raise BadArgument("`!roll` only supports between 1 and 6 rolls.")
 
     @commands.command(name="uwu", aliases=("uwuwize", "uwuify",))
     async def uwu_command(self, ctx: Context, *, text: clean_content(fix_channel_mentions=True)) -> None:

--- a/bot/exts/evergreen/fun.py
+++ b/bot/exts/evergreen/fun.py
@@ -57,17 +57,17 @@ class Fun(Cog):
         with Path("bot/resources/evergreen/caesar_info.json").open("r", encoding="UTF-8") as f:
             self._caesar_cipher_embed = json.load(f)
 
+    @staticmethod
+    def _get_random_die() -> str:
+        """Generate a random die emoji, ready to be sent on Discord."""
+        die_name = f"dice_{random.randint(1, 6)}"
+        return getattr(Emojis, die_name)
+
     @commands.command()
     async def roll(self, ctx: Context, num_rolls: int = 1) -> None:
         """Outputs a number of random dice emotes (up to 6)."""
-        def _get_random_die() -> str:
-            """Generate a random die emoji, ready to be sent on Discord."""
-            die_name = f"dice_{random.randint(1, 6)}"
-            return getattr(Emojis, die_name)
-
-        # Only support between 1 and 6 rolls
         if 1 <= num_rolls <= 6:
-            dice = " ".join(_get_random_die() for _ in range(num_rolls))
+            dice = " ".join(Fun._get_random_die() for _ in range(num_rolls))
             await ctx.send(dice)
         else:
             raise BadArgument("`!roll` only supports between 1 and 6 rolls.")

--- a/bot/exts/evergreen/fun.py
+++ b/bot/exts/evergreen/fun.py
@@ -67,7 +67,7 @@ class Fun(Cog):
     async def roll(self, ctx: Context, num_rolls: int = 1) -> None:
         """Outputs a number of random dice emotes (up to 6)."""
         if 1 <= num_rolls <= 6:
-            dice = " ".join(Fun._get_random_die() for _ in range(num_rolls))
+            dice = " ".join(self._get_random_die() for _ in range(num_rolls))
             await ctx.send(dice)
         else:
             raise BadArgument("`!roll` only supports between 1 and 6 rolls.")

--- a/bot/exts/evergreen/fun.py
+++ b/bot/exts/evergreen/fun.py
@@ -60,13 +60,15 @@ class Fun(Cog):
     @commands.command()
     async def roll(self, ctx: Context, num_rolls: int = 1) -> None:
         """Outputs a number of random dice emotes (up to 6)."""
+        output = ""
         if num_rolls > 6:
             num_rolls = 6
-
-        dice = (f"dice_{random.randint(1, 6)}" for _ in range(num_rolls))
-        output = " ".join(getattr(Emojis, die, '') for die in dice)
-
-        await ctx.send(output or ":no_entry: You must roll at least once.")
+        elif num_rolls < 1:
+            output = ":no_entry: You must roll at least once."
+        for _ in range(num_rolls):
+            dice = f"dice_{random.randint(1, 6)}"
+            output += getattr(Emojis, dice, '') + " "
+        await ctx.send(output.rstrip())
 
     @commands.command(name="uwu", aliases=("uwuwize", "uwuify",))
     async def uwu_command(self, ctx: Context, *, text: clean_content(fix_channel_mentions=True)) -> None:

--- a/bot/exts/evergreen/fun.py
+++ b/bot/exts/evergreen/fun.py
@@ -60,15 +60,13 @@ class Fun(Cog):
     @commands.command()
     async def roll(self, ctx: Context, num_rolls: int = 1) -> None:
         """Outputs a number of random dice emotes (up to 6)."""
-        output = ""
         if num_rolls > 6:
             num_rolls = 6
-        elif num_rolls < 1:
-            output = ":no_entry: You must roll at least once."
-        for _ in range(num_rolls):
-            dice = f"dice_{random.randint(1, 6)}"
-            output += getattr(Emojis, dice, '')
-        await ctx.send(output)
+
+        dice = (f"dice_{random.randint(1, 6)}" for _ in range(num_rolls))
+        output = " ".join(getattr(Emojis, die, '') for die in dice)
+
+        await ctx.send(output or ":no_entry: You must roll at least once.")
 
     @commands.command(name="uwu", aliases=("uwuwize", "uwuify",))
     async def uwu_command(self, ctx: Context, *, text: clean_content(fix_channel_mentions=True)) -> None:


### PR DESCRIPTION
## Description
<!-- Describe how you've implemented your changes. -->
The `.roll` command now has a single space between the outputted dice, when more than 1 roll is specified. The code behind the command is also a lot more refined.

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
Previously, when given a number greater than 1, the `.roll` command sent the dice without space between them. This resulted in it looking quite strange.

## Screenshots
<!-- Remove this section if the changes don't impact anything user-facing. -->
<!-- You can add images by just copy pasting them directly in the editor. -->
Current:
<img width="321" alt="Screenshot 2020-10-04 at 22 45 35" src="https://user-images.githubusercontent.com/65498475/95026673-528f1500-0693-11eb-83c5-b1a1ecab99da.png">

Proposed:
<img width="333" alt="Screenshot 2020-10-04 at 22 45 16" src="https://user-images.githubusercontent.com/65498475/95026668-486d1680-0693-11eb-9024-cce9cd54ff8b.png">

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?