### PR TITLE
Limit issue body to 500 characters

### DIFF
--- a/bot/exts/halloween/hacktober-issue-finder.py
+++ b/bot/exts/halloween/hacktober-issue-finder.py
@@ -103,7 +103,7 @@ class HacktoberIssues(commands.Cog):
         labels = [label["name"] for label in issue["labels"]]
 
         embed = discord.Embed(title=title)
-        embed.description = body
+        embed.description = body[:500] + '....' if len(body) > 500 else body
         embed.add_field(name="labels", value="\n".join(labels))
         embed.url = issue_url
         embed.set_footer(text=issue_url)

--- a/bot/exts/halloween/hacktober-issue-finder.py
+++ b/bot/exts/halloween/hacktober-issue-finder.py
@@ -103,7 +103,7 @@ class HacktoberIssues(commands.Cog):
         labels = [label["name"] for label in issue["labels"]]
 
         embed = discord.Embed(title=title)
-        embed.description = body[:500] + '....' if len(body) > 500 else body
+        embed.description = body[:500] + '...' if len(body) > 500 else body
         embed.add_field(name="labels", value="\n".join(labels))
         embed.url = issue_url
         embed.set_footer(text=issue_url)


### PR DESCRIPTION
## Relevant Issues
Closes #486 

## Description
This PR puts a limit on how long the response sent by the `.hacktoberissues` is going to be by limiting the issue body up to it's first 500 characters. This avoids http 400 errors (see #486 ) when dealing with issues with very long body.

## Did you:
- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
