### PR TITLE
Fix snake video command

### DIFF
--- a/bot/exts/evergreen/snakes/_snakes_cog.py
+++ b/bot/exts/evergreen/snakes/_snakes_cog.py
@@ -1089,7 +1089,7 @@ class Snakes(Cog):
             }
         )
         response = await response.json()
-        data = response['items']
+        data = response.get("items", [])
 
         # Send the user a video
         if len(data) > 0:

--- a/bot/exts/evergreen/snakes/_snakes_cog.py
+++ b/bot/exts/evergreen/snakes/_snakes_cog.py
@@ -1083,7 +1083,7 @@ class Snakes(Cog):
             url,
             params={
                 "part": "snippet",
-                "q": urllib.parse.quote(query),
+                "q": urllib.parse.quote_plus(query),
                 "type": "video",
                 "key": Tokens.youtube
             }


### PR DESCRIPTION
## Relevant Issues
<!-- List relevant issue tickets here. -->
<!-- Say "Closes #0" for issues that the PR resolves, replacing 0 with the issue number. -->
Closes #490


## Description
<!-- Describe how you've implemented your changes. -->
After testing, I found that `urllib.parse.quote` is parsing spaces to `%2520%` that YouTube API don't support. Changing this to `urllib.parse.quote_plus` make this parsing spaces to `+` what YouTube API can read and then return again proper response with `items` key defined.


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
