### PR TITLE
Fix candy mini-game to group leader-board scores correctly

### DIFF
--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -107,7 +107,7 @@ class CandyCollection(commands.Cog):
         else:
             return  # Skip saving
 
-        await CandyCollection.remove_reactions(reaction)
+        await reaction.clear()
         await self.bot.loop.run_in_executor(None, self.save_to_json)
 
     async def reacted_msg_chance(self, message: discord.Message) -> None:
@@ -146,16 +146,6 @@ class CandyCollection(commands.Cog):
     async def hacktober_channel(self) -> discord.TextChannel:
         """Get #hacktoberbot channel from its ID."""
         return self.bot.get_channel(id=Channels.seasonalbot_commands)
-
-    @classmethod
-    async def remove_reactions(cls, reaction: discord.Reaction) -> None:
-        """Remove all candy/skull reactions."""
-        try:
-            async for user in reaction.users():
-                await reaction.message.remove_reaction(reaction.emoji, user)
-
-        except discord.HTTPException:
-            pass
 
     @classmethod
     async def send_spook_msg(cls, author: discord.Member, channel: discord.TextChannel,

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -96,20 +96,21 @@ class CandyCollection(commands.Cog):
 
         if message.id in self.candy_messages and str(reaction.emoji) == EMOJIS['CANDY']:
             self.candy_messages.remove(message.id)
-            prev_record = self.candy_records.get(str(message.author.id), 0)
-            self.candy_records[str(message.author.id)] = prev_record + 1
+            prev_record = self.candy_records.get(str(user.id), 0)
+            self.candy_records[str(user.id)] = prev_record + 1
 
         elif message.id in self.skull_messages and str(reaction.emoji) == EMOJIS['SKULL']:
             self.skull_messages.remove(message.id)
 
-            if (prev_record := self.candy_records.get(str(message.author.id))) is not None:
+            # Skip if no past score exists or if it's 0
+            if prev_record := self.candy_records.get(str(user.id)):
                 lost = min(random.randint(1, 3), prev_record)
-                self.candy_records[str(message.author.id)] = prev_record - lost
+                self.candy_records[str(user.id)] = prev_record - lost
 
                 if lost == prev_record:
-                    await CandyCollection.send_spook_msg(message.author, message.channel, 'all of your')
+                    await CandyCollection.send_spook_msg(user, message.channel, 'all of your')
                 else:
-                    await CandyCollection.send_spook_msg(message.author, message.channel, lost)
+                    await CandyCollection.send_spook_msg(user, message.channel, lost)
         else:
             return  # Skip saving
 

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -1,7 +1,7 @@
 import json
 import logging
-import os
 import random
+from pathlib import Path
 from typing import Union
 
 import discord
@@ -9,10 +9,9 @@ from discord.ext import commands
 
 from bot.constants import Channels, Month
 from bot.utils.decorators import in_month
+from bot.utils.persist import make_persistent
 
 log = logging.getLogger(__name__)
-
-json_location = os.path.join("bot", "resources", "halloween", "candy_collection.json")
 
 # chance is 1 in x range, so 1 in 20 range would give 5% chance (for add candy)
 ADD_CANDY_REACTION_CHANCE = 20  # 5%
@@ -38,8 +37,10 @@ class CandyCollection(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
-        with open(json_location, encoding="utf8") as candy:
-            candy_data = json.load(candy)
+        self.json_file = make_persistent(Path("bot", "resources", "halloween", "candy_collection.json"))
+
+        with self.json_file.open() as fp:
+            candy_data = json.load(fp)
 
         # The rank data
         self.candy_records = candy_data.get("records", dict())
@@ -145,8 +146,8 @@ class CandyCollection(commands.Cog):
 
     def save_to_json(self) -> None:
         """Save JSON to a local file."""
-        with open(json_location, 'w', encoding="utf8") as outfile:
-            json.dump(dict(records=self.candy_records), outfile)
+        with self.json_file.open('w') as fp:
+            json.dump(dict(records=self.candy_records), fp)
 
     @in_month(Month.OCTOBER)
     @commands.command()

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -22,12 +22,13 @@ ADD_SKULL_EXISTING_REACTION_CHANCE = 20  # 5%
 EMOJIS = dict(
     CANDY="\N{CANDY}",
     SKULL="\N{SKULL}",
-    MEDALS=('\N{FIRST PLACE MEDAL}',
-            '\N{SECOND PLACE MEDAL}',
-            '\N{THIRD PLACE MEDAL}',
-            '\N{SPORTS MEDAL}',
-            '\N{SPORTS MEDAL}',
-            ),
+    MEDALS=(
+        '\N{FIRST PLACE MEDAL}',
+        '\N{SECOND PLACE MEDAL}',
+        '\N{THIRD PLACE MEDAL}',
+        '\N{SPORTS MEDAL}',
+        '\N{SPORTS MEDAL}',
+    ),
 )
 
 
@@ -136,8 +137,9 @@ class CandyCollection(commands.Cog):
         return self.bot.get_channel(id=Channels.seasonalbot_commands)
 
     @classmethod
-    async def send_spook_msg(cls, author: discord.Member, channel: discord.TextChannel,
-                             candies: Union[str, int]) -> None:
+    async def send_spook_msg(
+        cls, author: discord.Member, channel: discord.TextChannel, candies: Union[str, int]
+    ) -> None:
         """Send a spooky message."""
         e = discord.Embed(colour=author.colour)
         e.set_author(name="Ghosts and Ghouls and Jack o' lanterns at night; "
@@ -161,8 +163,10 @@ class CandyCollection(commands.Cog):
             )
             top_five = top_sorted[:5]
 
-            return '\n'.join(f"{EMOJIS['MEDALS'][index]} <@{record[0]}>: {record[1]}"
-                             for index, record in enumerate(top_five)) if top_five else 'No Candies'
+            return '\n'.join(
+                f"{EMOJIS['MEDALS'][index]} <@{record[0]}>: {record[1]}"
+                for index, record in enumerate(top_five)
+            ) if top_five else 'No Candies'
 
         e = discord.Embed(colour=discord.Colour.blurple())
         e.add_field(

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -100,7 +100,6 @@ class CandyCollection(commands.Cog):
         elif message.id in self.skull_messages and str(reaction.emoji) == EMOJIS['SKULL']:
             self.skull_messages.remove(message.id)
 
-            # Skip if no past score exists or if it's 0
             if prev_record := self.candy_records.get(str(user.id)):
                 lost = min(random.randint(1, 3), prev_record)
                 self.candy_records[str(user.id)] = prev_record - lost
@@ -109,6 +108,8 @@ class CandyCollection(commands.Cog):
                     await CandyCollection.send_spook_msg(user, message.channel, 'all of your')
                 else:
                     await CandyCollection.send_spook_msg(user, message.channel, lost)
+            else:
+                await CandyCollection.send_no_candy_spook_message(user, message.channel)
         else:
             return  # Skip saving
 
@@ -144,6 +145,19 @@ class CandyCollection(commands.Cog):
         e.set_author(name="Ghosts and Ghouls and Jack o' lanterns at night; "
                           f"I took {candies} candies and quickly took flight.")
         await channel.send(embed=e)
+
+    @staticmethod
+    async def send_no_candy_spook_message(
+        author: discord.Member,
+        channel: discord.TextChannel
+    ) -> None:
+        """An alternative spooky message sent when user has no candies in the
+        collection"""
+
+        embed = discord.Embed(color=author.color)
+        embed.set_author(name="Ghosts and Ghouls and Jack o' lanterns at night; "
+                              f"I tried to take your candies but you had non to begin with!")
+        await channel.send(embed=embed)
 
     def save_to_json(self) -> None:
         """Save JSON to a local file."""

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -136,9 +136,9 @@ class CandyCollection(commands.Cog):
         """Get #hacktoberbot channel from its ID."""
         return self.bot.get_channel(id=Channels.seasonalbot_commands)
 
-    @classmethod
+    @staticmethod
     async def send_spook_msg(
-        cls, author: discord.Member, channel: discord.TextChannel, candies: Union[str, int]
+        author: discord.Member, channel: discord.TextChannel, candies: Union[str, int]
     ) -> None:
         """Send a spooky message."""
         e = discord.Embed(colour=author.colour)

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -1,4 +1,3 @@
-import functools
 import json
 import logging
 import os
@@ -94,7 +93,7 @@ class CandyCollection(commands.Cog):
                 else:
                     await self.send_spook_msg(message.author, message.channel, lost)
         else:
-            return # Skip saving
+            return  # Skip saving
 
         await self.remove_reactions(reaction)
         await self.bot.loop.run_in_executor(None, self.save_to_json)
@@ -177,7 +176,6 @@ class CandyCollection(commands.Cog):
     @commands.command()
     async def candy(self, ctx: commands.Context) -> None:
         """Get the candy leaderboard and save to JSON."""
-
         emoji = (
             '\N{FIRST PLACE MEDAL}',
             '\N{SECOND PLACE MEDAL}',
@@ -186,12 +184,12 @@ class CandyCollection(commands.Cog):
             '\N{SPORTS MEDAL}'
         )
 
-        top_sorted = sorted(((user_id, score) for user_id, score in self.candy_records.items()), \
-            key=lambda x: x[1], reverse=True)
+        top_sorted = sorted(((user_id, score) for user_id, score in self.candy_records.items()),
+                            key=lambda x: x[1], reverse=True)
         top_five = top_sorted[:5]
 
         leaderboard = '\n'.join(f"{emoji[index]} <@{record[0]}>: {record[1]}"
-            for index, record in enumerate(top_five)) or 'No Candies'
+                                for index, record in enumerate(top_five)) or 'No Candies'
 
         e = discord.Embed(colour=discord.Colour.blurple())
         e.add_field(name="Top Candy Records", value=leaderboard, inline=False)

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -154,7 +154,7 @@ class CandyCollection(commands.Cog):
         """An alternative spooky message sent when user has no candies in the collection."""
         embed = discord.Embed(color=author.color)
         embed.set_author(name="Ghosts and Ghouls and Jack o' lanterns at night; "
-                              "I tried to take your candies but you had non to begin with!")
+                              "I tried to take your candies but you had none to begin with!")
         await channel.send(embed=embed)
 
     def save_to_json(self) -> None:

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -87,6 +87,7 @@ class CandyCollection(commands.Cog):
 
             if (prev_record := self.candy_records.get(str(message.author.id))) is not None:
                 lost = min(random.randint(1, 3), prev_record)
+                self.candy_records[str(message.author.id)] = prev_record - lost
 
                 if lost == prev_record:
                     await self.send_spook_msg(message.author, message.channel, 'all of your')

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -143,22 +143,6 @@ class CandyCollection(commands.Cog):
 
         return ten_recent
 
-    async def get_message(self, msg_id: int) -> Union[discord.Message, None]:
-        """Get the message from its ID."""
-        try:
-            o = discord.Object(id=msg_id + 1)
-            # Use history rather than get_message due to
-            #         poor ratelimit (50/1s vs 1/1s)
-            msg = await next(self.hacktober_channel.history(limit=1, before=o))
-
-            if msg.id != msg_id:
-                return None
-
-            return msg
-
-        except Exception:
-            return None
-
     async def hacktober_channel(self) -> discord.TextChannel:
         """Get #hacktoberbot channel from its ID."""
         return self.bot.get_channel(id=Channels.seasonalbot_commands)

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -151,12 +151,10 @@ class CandyCollection(commands.Cog):
         author: discord.Member,
         channel: discord.TextChannel
     ) -> None:
-        """An alternative spooky message sent when user has no candies in the
-        collection"""
-
+        """An alternative spooky message sent when user has no candies in the collection."""
         embed = discord.Embed(color=author.color)
         embed.set_author(name="Ghosts and Ghouls and Jack o' lanterns at night; "
-                              f"I tried to take your candies but you had non to begin with!")
+                              "I tried to take your candies but you had non to begin with!")
         await channel.send(embed=embed)
 
     def save_to_json(self) -> None:

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import random
-from typing import List, Union
+from typing import Union
 
 import discord
 from discord.ext import commands
@@ -84,7 +84,11 @@ class CandyCollection(commands.Cog):
         # if its not a candy or skull, and it is one of 10 most recent messages,
         # proceed to add a skull/candy with higher chance
         if str(reaction.emoji) not in (EMOJIS['SKULL'], EMOJIS['CANDY']):
-            if message.id in await self.ten_recent_msg():
+            recent_message_ids = map(
+                lambda m: m.id,
+                await self.hacktober_channel.history(limit=10).flatten()
+            )
+            if message.id in recent_message_ids:
                 await self.reacted_msg_chance(message)
             return
 
@@ -125,25 +129,8 @@ class CandyCollection(commands.Cog):
             self.candy_messages.add(message.id)
             return await message.add_reaction(EMOJIS['CANDY'])
 
-    async def ten_recent_msg(self) -> List[int]:
-        """Get the last 10 messages sent in the channel."""
-        ten_recent = []
-        recent_msg_id = max(
-            message.id for message in self.bot._connection._messages
-            if message.channel.id == Channels.seasonalbot_commands
-        )
-
-        channel = await self.hacktober_channel()
-        ten_recent.append(recent_msg_id)
-
-        for i in range(9):
-            o = discord.Object(id=recent_msg_id + i)
-            msg = await next(channel.history(limit=1, before=o))
-            ten_recent.append(msg.id)
-
-        return ten_recent
-
-    async def hacktober_channel(self) -> discord.TextChannel:
+    @property
+    def hacktober_channel(self) -> discord.TextChannel:
         """Get #hacktoberbot channel from its ID."""
         return self.bot.get_channel(id=Channels.seasonalbot_commands)
 

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -175,23 +175,30 @@ class CandyCollection(commands.Cog):
     @commands.command()
     async def candy(self, ctx: commands.Context) -> None:
         """Get the candy leaderboard and save to JSON."""
-        top_sorted = sorted(
-            ((user_id, score) for user_id, score in self.candy_records.items()),
-            key=lambda x: x[1],
-            reverse=True
-        )
-        top_five = top_sorted[:5]
+        def generate_leaderboard() -> str:
+            top_sorted = sorted(
+                ((user_id, score) for user_id, score in self.candy_records.items() if score > 0),
+                key=lambda x: x[1],
+                reverse=True
+            )
+            top_five = top_sorted[:5]
 
-        leaderboard = '\n'.join(f"{EMOJIS['MEDALS'][index]} <@{record[0]}>: {record[1]}"
-                                for index, record in enumerate(top_five)) or 'No Candies'
+            return '\n'.join(f"{EMOJIS['MEDALS'][index]} <@{record[0]}>: {record[1]}"
+                             for index, record in enumerate(top_five)) if top_five else 'No Candies'
 
         e = discord.Embed(colour=discord.Colour.blurple())
-        e.add_field(name="Top Candy Records", value=leaderboard, inline=False)
-        e.add_field(name='\u200b',
-                    value="Candies will randomly appear on messages sent. "
-                          "\nHit the candy when it appears as fast as possible to get the candy! "
-                          "\nBut beware the ghosts...",
-                    inline=False)
+        e.add_field(
+            name="Top Candy Records",
+            value=generate_leaderboard(),
+            inline=False
+        )
+        e.add_field(
+            name='\u200b',
+            value="Candies will randomly appear on messages sent. "
+                  "\nHit the candy when it appears as fast as possible to get the candy! "
+                  "\nBut beware the ghosts...",
+            inline=False
+        )
         await ctx.send(embed=e)
 
 

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -37,13 +37,11 @@ class CandyCollection(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-
         self.json_file = make_persistent(Path("bot", "resources", "halloween", "candy_collection.json"))
 
         with self.json_file.open() as fp:
             candy_data = json.load(fp)
 
-        # The rank data
         self.candy_records = candy_data.get("records", dict())
 
         # Message ID where bot added the candies/skulls

--- a/bot/resources/halloween/candy_collection.json
+++ b/bot/resources/halloween/candy_collection.json
@@ -1,1 +1,1 @@
-{"msg_reacted": [{"reaction": "\ud83c\udf6c", "msg_id": 514442189359546375, "won": true, "user_reacted": 95872159741644800}, {"reaction": "\ud83c\udf6c", "msg_id": 514442502460276740, "won": true, "user_reacted": 178876748224659457}], "records": [{"userid": 95872159741644800, "record": 1}, {"userid": 178876748224659457, "record": 1}]}
+{}


### PR DESCRIPTION
## Relevant Issues
<!-- List relevant issue tickets here. -->
<!-- Say "Closes #0" for issues that the PR resolves, replacing 0 with the issue number. -->
Closes #495, #477 and #284 

## Description
<!-- Describe how you've implemented your changes. -->
The older code was storing candy spawn information in the json, which I think is unnecessary. I have replaced it all with two `set`s- `candy_messages` and `skull_messages` which contain the message ids of the messages where the spawns were made and pop them out when someone reacts to it.
The old schema looked like-
```json
{
   "msg_reacted": [
      {
         "reaction":" \ud83c\udf6c",
         "msg_id": 514442502460276740,
         "won": true,
         "user_reacted": 721012149933310029
      }
   ],

   "records": [
      {
         "userid": 721012149933310029,
         "record": 2
      },
   ]
}
```

Which is now simplified to-
```json
{
    "records" : {
        "721012149933310029": 2
     }
}
```
Which makes it simple to group the score in leader-board (which was what wrong in the issue #495)
## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
I think there is no reason for the spawn data to be in the json, it can live in an in-memory set. The `records` is now a `dict` with user id as key and score as value which is automatically grouped correctly for the leader-board.

## Screenshots
<!-- Remove this section if the changes don't impact anything user-facing. -->
<!-- You can add images by just copy pasting them directly in the editor. -->
![A screenshot showing grouped leader-board score](https://i.imgur.com/NnUCmT3.png)

## Additional Details
A question: Shouldn't the json file be in the `.gitignore`? Wouldn't they clear the existing data on each deploy if they are a part of the git repo?


## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
