### PR TITLE
fix the use of next() for HistoryIterator object

### DIFF
--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -135,7 +135,7 @@ class CandyCollection(commands.Cog):
 
         for i in range(9):
             o = discord.Object(id=recent_msg_id + i)
-            msg = await channel.history(limit=1, before=o).next()  # noqa: B305
+            msg = await channel.history(limit=1, before=o).next()
             ten_recent.append(msg.id)
 
         return ten_recent
@@ -146,7 +146,7 @@ class CandyCollection(commands.Cog):
             o = discord.Object(id=msg_id + 1)
             # Use history rather than get_message due to
             #         poor ratelimit (50/1s vs 1/1s)
-            msg = await self.hacktober_channel.history(limit=1, before=o).next()  # noqa: B305
+            msg = await self.hacktober_channel.history(limit=1, before=o).next()
 
             if msg.id != msg_id:
                 return None

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -135,7 +135,7 @@ class CandyCollection(commands.Cog):
 
         for i in range(9):
             o = discord.Object(id=recent_msg_id + i)
-            msg = await next(channel.history(limit=1, before=o))
+            msg = await channel.history(limit=1, before=o).next()
             ten_recent.append(msg.id)
 
         return ten_recent
@@ -146,7 +146,7 @@ class CandyCollection(commands.Cog):
             o = discord.Object(id=msg_id + 1)
             # Use history rather than get_message due to
             #         poor ratelimit (50/1s vs 1/1s)
-            msg = await next(self.hacktober_channel.history(limit=1, before=o))
+            msg = await self.hacktober_channel.history(limit=1, before=o).next()
 
             if msg.id != msg_id:
                 return None

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -135,7 +135,7 @@ class CandyCollection(commands.Cog):
 
         for i in range(9):
             o = discord.Object(id=recent_msg_id + i)
-            msg = await channel.history(limit=1, before=o).next()
+            msg = await channel.history(limit=1, before=o).next()  # noqa: B305
             ten_recent.append(msg.id)
 
         return ten_recent
@@ -146,7 +146,7 @@ class CandyCollection(commands.Cog):
             o = discord.Object(id=msg_id + 1)
             # Use history rather than get_message due to
             #         poor ratelimit (50/1s vs 1/1s)
-            msg = await self.hacktober_channel.history(limit=1, before=o).next()
+            msg = await self.hacktober_channel.history(limit=1, before=o).next()  # noqa: B305
 
             if msg.id != msg_id:
                 return None

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ ignore=
     D400,D401,D402,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414,D416,D417
     # Type Annotations
     ANN002,ANN003,ANN101,ANN102,ANN204,ANN206
+    # bugbear
+    B305
 exclude=
     __pycache__,.cache,
     venv,.venv,


### PR DESCRIPTION

## Relevant Issues
<!-- List relevant issue tickets here. -->
<!-- Say "Closes #0" for issues that the PR resolves, replacing 0 with the issue number. -->
closes #477 

## Description
<!-- Describe how you've implemented your changes. -->
this fixes candy_collection.py throwing
`TypeError: 'HistoryIterator' object is not an iterator` when
an arrow button is pressed after the .help command.

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
**Before**:
```
Traceback (most recent call last):
  File "/home/hedy/.local/share/virtualenvs/seasonalbot-S5lMGbTO/lib/python3.8/site-packages/discord/client.py", line 312, in _run_event
    await coro(*args, **kwargs)
  File "/mnt/c/Users/hedyh/codeproj/seasonalbot/bot/utils/decorators.py", line 79, in guarded_listener
    return await listener(*args, **kwargs)
  File "/mnt/c/Users/hedyh/codeproj/seasonalbot/bot/exts/halloween/candy_collection.py", line 76, in on_reaction_add
    if message.id in await self.ten_recent_msg():
  File "/mnt/c/Users/hedyh/codeproj/seasonalbot/bot/exts/halloween/candy_collection.py", line 138, in ten_recent_msg
    msg = await next(channel.history(limit=1, before=o))
TypeError: 'HistoryIterator' object is not an iterator
```

**After**:
No traceback error

Because this is an incorrect use of built-in `next()`, and `discord.iterators.HistoryIterator` has their own [`.next` method](https://github.com/Rapptz/discord.py/blob/f308f34db1b1c24178fbdb1756838064cd9e4348/discord/iterators.py#L258)

## Additional Details

~~When I tried this a few days ago, flake8 told me:
```bot/exts/halloween/candy_collection.py:138:25: B305 `.next()` is not a thing on Python 3. Use the `next()` builtin. For Python 2 compatibility, use `six.next()`.```
And i thought i needed to add a `# noqa` to it, but now I ran flake8 and it doesn't give any errors/warnings at all.~~

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
~~If dependencies have been added or updated, run `pipenv lock`?~~
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
