### PR TITLE
Change error message for roll command to use the correct prefix

### DIFF
--- a/bot/exts/evergreen/fun.py
+++ b/bot/exts/evergreen/fun.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 from discord.ext.commands import BadArgument, Bot, Cog, Context, MessageConverter, clean_content
 
 from bot import utils
-from bot.constants import Colours, Emojis
+from bot.constants import Client, Colours, Emojis
 
 log = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class Fun(Cog):
             dice = " ".join(self._get_random_die() for _ in range(num_rolls))
             await ctx.send(dice)
         else:
-            raise BadArgument("`!roll` only supports between 1 and 6 rolls.")
+            raise BadArgument(f"`{Client.prefix}roll` only supports between 1 and 6 rolls.")
 
     @commands.command(name="uwu", aliases=("uwuwize", "uwuify",))
     async def uwu_command(self, ctx: Context, *, text: clean_content(fix_channel_mentions=True)) -> None:


### PR DESCRIPTION
## Description
<!-- Describe how you've implemented your changes. -->
The command previously sent `!` as the prefix, while `.` is the correct one. Now imports prefix from `bot.constants`, so it'll always be up to date.

## Screenshots
<!-- Remove this section if the changes don't impact anything user-facing. -->
<!-- You can add images by just copy pasting them directly in the editor. -->
**Previous output:**
<img width="488" alt="Screenshot 2020-10-18 at 17 45 52" src="https://user-images.githubusercontent.com/65498475/96372952-c5a38b80-1169-11eb-9e07-3f95f4da34c6.png">
**New output:**
<img width="491" alt="Screenshot 2020-10-18 at 17 46 27" src="https://user-images.githubusercontent.com/65498475/96372965-da801f00-1169-11eb-968c-32528e4ddbae.png">
## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
