### PR TITLE
fix keyerror for hackstats

### DIFF
--- a/bot/exts/halloween/hacktoberstats.py
+++ b/bot/exts/halloween/hacktoberstats.py
@@ -307,7 +307,7 @@ class HacktoberStats(commands.Cog):
             # if the PR has 'invalid' or 'spam' labels, the PR must be
             # either merged or approved for it to be included
             if HacktoberStats._has_label(item, ["invalid", "spam"]):
-                if not await HacktoberStats._is_accepted(item):
+                if not await HacktoberStats._is_accepted(itemdict):
                     continue
 
             # PRs before oct 3 no need to check for topics


### PR DESCRIPTION
## Description
<!-- Describe how you've implemented your changes. -->
hot fix for the `hackstats` command

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
it was raising key error:
![E3FA0F7C-B992-4E5A-8C49-D5B9DC984E8A](https://user-images.githubusercontent.com/50042066/96712292-7c557500-13d1-11eb-938d-acfdf20190c0.png)

and it seems that `item` was wrongly passed to `_is_accepted` and it should be `itemdict`

## Screenshots
<!-- Remove this section if the changes don't impact anything user-facing. -->
<!-- You can add images by just copy pasting them directly in the editor. -->
now it works for users that need checking for acceptance
![140C34DB-3269-466B-A40F-4B997461A08B](https://user-images.githubusercontent.com/50042066/96712395-a73fc900-13d1-11eb-9efa-e7f763b4da8a.jpeg)
