### PR TITLE
Hackstats: fix time and date specifics

### DIFF
--- a/bot/exts/halloween/hacktoberstats.py
+++ b/bot/exts/halloween/hacktoberstats.py
@@ -259,7 +259,7 @@ class HacktoberStats(commands.Cog):
         action_type = "pr"
         is_query = "public"
         not_query = "draft"
-        date_range = f"{CURRENT_YEAR}-10-01T00:00:00%2B14:00..{CURRENT_YEAR}-11-01T00:00:00-11:00"
+        date_range = f"{CURRENT_YEAR}-09-30T10:00Z..{CURRENT_YEAR}-11-01T12:00Z"
         per_page = "300"
         query_url = (
             f"{base_url}"
@@ -291,7 +291,7 @@ class HacktoberStats(commands.Cog):
 
         logging.info(f"Found {len(jsonresp['items'])} Hacktoberfest PRs for GitHub user: '{github_username}'")
         outlist = []  # list of pr information dicts that will get returned
-        oct3 = datetime(int(CURRENT_YEAR), 10, 3, 0, 0, 0)
+        oct3 = datetime(int(CURRENT_YEAR), 10, 3, 23, 59, 59, tzinfo=None)
         hackto_topics = {}  # cache whether each repo has the appropriate topic (bool values)
         for item in jsonresp["items"]:
             shortname = HacktoberStats._get_shortname(item["repository_url"])
@@ -434,12 +434,13 @@ class HacktoberStats(commands.Cog):
         'hacktoberfest-accepted.
         """
         now = datetime.now()
+        oct3 = datetime(CURRENT_YEAR, 10, 3, 23, 59, 59, tzinfo=None)
         in_review = []
         accepted = []
         for pr in prs:
             if (pr['created_at'] + timedelta(REVIEW_DAYS)) > now:
                 in_review.append(pr)
-            elif await HacktoberStats._is_accepted(pr):
+            elif (pr['created_at'] <= oct3) or await HacktoberStats._is_accepted(pr):
                 accepted.append(pr)
 
         return in_review, accepted


### PR DESCRIPTION
## Description
<!-- Describe how you've implemented your changes. -->
- Updated PRs 'created' time range to the range @mattipv4 told me
- updated categorising prs logic, now PRs that are after the review period but created before october 3rd will count

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
for some people the PRs listed wasn't the same as the ones on the website, those PRs are the ones from before october 3rd, and passed review period. Now it's listed

## Screenshots
<!-- Remove this section if the changes don't impact anything user-facing. -->
<!-- You can add images by just copy pasting them directly in the editor. -->
Before/after
![345B6A06-7130-4372-A7FA-22D4A6053B76](https://user-images.githubusercontent.com/50042066/96980938-1512fe80-1552-11eb-83ea-0e75512adb05.jpeg)
![3187CF34-7CF2-4DA9-A60C-39812D86C95A](https://user-images.githubusercontent.com/50042066/96981007-193f1c00-1552-11eb-9a66-7b6b1450067c.jpeg)

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- ~~If dependencies have been added or updated, run `pipenv lock`?~~
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?
