### PR TITLE
Remove DockerHub from GitHub Actions

### DIFF
--- a/.github/workflows/lint-build-deploy.yaml
+++ b/.github/workflows/lint-build-deploy.yaml
@@ -114,12 +114,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Login to Github Container Registry
         uses: docker/login-action@v1
         with:
@@ -127,9 +121,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN  }}
 
-      # This step currently pushes to both DockerHub and GHCR to
-      # make the migration easier. The DockerHub push will be
-      # removed once we've migrated to our K8s cluster.
+      # Build and push the container to the GitHub Container
+      # Repository. The container will be tagged as "latest"
+      # and with the short SHA of the commit.
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -140,8 +134,6 @@ jobs:
           tags: |
             ghcr.io/python-discord/seasonalbot:latest
             ghcr.io/python-discord/seasonalbot:${{ steps.sha_tag.outputs.tag }}
-            pythondiscord/seasonalbot:latest
-            pythondiscord/seasonalbot:${{ steps.sha_tag.outputs.tag }}
 
       - name: Authenticate with Kubernetes
         uses: azure/k8s-set-context@v1


### PR DESCRIPTION
We're no longer using DockerHub in our deployment for SeasonalBot, so it does not make sense to keep pushing containers there.
