### PR TITLE
Fix flake8 check in CI and separate Lint and Build jobs into separate workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,64 @@
+name: Build
+
+on:
+  workflow_run:
+    workflows: ["Lint"]
+    branches:
+      - master
+    types:
+      - completed
+
+jobs:
+  build:
+    if: github.event.workflow_run.conclusion == 'success'
+    name: Build, Push, & Deploy Container
+    runs-on: ubuntu-latest
+
+    steps:
+      # Create a commit SHA-based tag for the container repositories
+      - name: Create SHA Container Tag
+        id: sha_tag
+        run: |
+          tag=$(cut -c 1-7 <<< $GITHUB_SHA)
+          echo "::set-output name=tag::$tag"
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN  }}
+
+      # Build and push the container to the GitHub Container
+      # Repository. The container will be tagged as "latest"
+      # and with the short SHA of the commit.
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          cache-from: type=registry,ref=ghcr.io/python-discord/seasonalbot:latest
+          tags: |
+            ghcr.io/python-discord/seasonalbot:latest
+            ghcr.io/python-discord/seasonalbot:${{ steps.sha_tag.outputs.tag }}
+
+      - name: Authenticate with Kubernetes
+        uses: azure/k8s-set-context@v1
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.KUBECONFIG }}
+
+      - name: Deploy to Kubernetes
+        uses: Azure/k8s-deploy@v1
+        with:
+          manifests: |
+              deployment.yaml
+          images: 'ghcr.io/python-discord/seasonalbot:${{ steps.sha_tag.outputs.tag }}'
+          kubectl-version: 'latest'

--- a/.github/workflows/lint-build-deploy.yaml
+++ b/.github/workflows/lint-build-deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
 
 
 jobs:
@@ -32,12 +32,8 @@ jobs:
       - name: Add custom PYTHONUSERBASE to PATH
         run: echo '${{ env.PYTHONUSERBASE }}/bin/' >> $GITHUB_PATH
 
-      # We don't want to persist credentials, as our GitHub Action
-      # may be run when a PR is made from a fork.
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          persist-credentials: false
 
       - name: Setup python
         id: python
@@ -84,15 +80,17 @@ jobs:
       - name: Run pre-commit hooks
         run: export PIP_USER=0; SKIP=flake8 pre-commit run --all-files
 
-      # This step requires `pull_request_target` as we need "write" permissions
-      # to add annotations to the Actions results. A normal `pull_request` trigger
-      # does not get those permissions for security reasons.
+      # Run flake8 and have it format the linting errors in the format of
+      # the GitHub Workflow command to register error annotations. This
+      # means that our flake8 output is automatically added as an error
+      # annotation to both the run result and in the "Files" tab of a
+      # pull request.
+      #
+      # Format used:
+      # ::error file={filename},line={line},col={col}::{message}
       - name: Run flake8
-        uses: julianwachholz/flake8-action@v1
-        with:
-          checkName: lint
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: "flake8 \
+        --format='::error file=%(path)s,line=%(row)d,col=%(col)d::[flake8] %(code)s: %(text)s'"
 
   build-and-deploy:
     name: Build and Deploy to Kubernetes

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Lint, Build & Deploy
+name: Lint
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    name: Lint using pre-commit & flake8
+    name: Run pre-commit & flake8
     runs-on: ubuntu-latest
     env:
       # Configure pip to cache dependencies and do a user install
@@ -91,58 +91,3 @@ jobs:
       - name: Run flake8
         run: "flake8 \
         --format='::error file=%(path)s,line=%(row)d,col=%(col)d::[flake8] %(code)s: %(text)s'"
-
-  build-and-deploy:
-    name: Build and Deploy to Kubernetes
-    needs: lint
-    if: github.event_name != 'pull_request_target' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-
-    steps:
-      # Create a commit SHA-based tag for the container repositories
-      - name: Create SHA Container Tag
-        id: sha_tag
-        run: |
-          tag=$(cut -c 1-7 <<< $GITHUB_SHA)
-          echo "::set-output name=tag::$tag"
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Github Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN  }}
-
-      # Build and push the container to the GitHub Container
-      # Repository. The container will be tagged as "latest"
-      # and with the short SHA of the commit.
-      - name: Build and push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          cache-from: type=registry,ref=ghcr.io/python-discord/seasonalbot:latest
-          tags: |
-            ghcr.io/python-discord/seasonalbot:latest
-            ghcr.io/python-discord/seasonalbot:${{ steps.sha_tag.outputs.tag }}
-
-      - name: Authenticate with Kubernetes
-        uses: azure/k8s-set-context@v1
-        with:
-          method: kubeconfig
-          kubeconfig: ${{ secrets.KUBECONFIG }}
-
-      - name: Deploy to Kubernetes
-        uses: Azure/k8s-deploy@v1
-        with:
-          manifests: |
-              deployment.yaml
-          images: 'ghcr.io/python-discord/seasonalbot:${{ steps.sha_tag.outputs.tag }}'
-          kubectl-version: 'latest'

--- a/bot/exts/evergreen/branding.py
+++ b/bot/exts/evergreen/branding.py
@@ -1,6 +1,6 @@
 import asyncio
 import itertools
-import json
+# import json
 import logging
 import random
 import typing as t
@@ -18,7 +18,7 @@ from bot.seasons import SeasonBase, get_all_seasons, get_current_season, get_sea
 from bot.utils import human_months
 from bot.utils.decorators import with_role
 from bot.utils.exceptions import BrandingError
-# TODO: Implement substitute for current volume persistence requirements
+# TODO: Implement substitute for current volume persistence requirements  # noqa: T000
 # from bot.utils.persist import make_persistent
 
 log = logging.getLogger(__name__)

--- a/bot/exts/halloween/candy_collection.py
+++ b/bot/exts/halloween/candy_collection.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import random
-from pathlib import Path
+# from pathlib import Path
 from typing import Union
 
 import discord
@@ -10,7 +10,7 @@ from discord.ext import commands
 from bot.constants import Channels, Month
 from bot.utils.decorators import in_month
 
-# TODO: Implement substitutes for volume-persistent methods.
+# TODO: Implement substitutes for volume-persistent methods.  # noqa: T000
 # from bot.utils.persist import make_persistent
 
 log = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ class CandyCollection(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self.json_file = make_persistent(Path("bot", "resources", "halloween", "candy_collection.json"))
+        # self.json_file = make_persistent(Path("bot", "resources", "halloween", "candy_collection.json"))
 
         with self.json_file.open() as fp:
             candy_data = json.load(fp)

--- a/bot/exts/halloween/hacktoberstats.py
+++ b/bot/exts/halloween/hacktoberstats.py
@@ -3,7 +3,7 @@ import logging
 import re
 from collections import Counter
 from datetime import datetime, timedelta
-from pathlib import Path
+# from pathlib import Path
 from typing import List, Tuple, Union
 
 import aiohttp
@@ -13,7 +13,7 @@ from discord.ext import commands
 from bot.constants import Channels, Month, Tokens, WHITELISTED_CHANNELS
 from bot.utils.decorators import in_month, override_in_channel
 
-# TODO: Implement substitutes for volume-persistent methods.
+# TODO: Implement substitutes for volume-persistent methods.  # noqa: T000
 # from bot.utils.persist import make_persistent
 
 log = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ class HacktoberStats(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self.link_json = make_persistent(Path("bot", "resources", "halloween", "github_links.json"))
+        # self.link_json = make_persistent(Path("bot", "resources", "halloween", "github_links.json"))
         self.linked_accounts = self.load_linked_users()
 
     @in_month(Month.SEPTEMBER, Month.OCTOBER, Month.NOVEMBER)


### PR DESCRIPTION
This PR makes two changes to our CI:

#### 1. Instead of using a predefined action, we now use `flake8` directly to generate annotations for a CI check

Unfortunately, the flake8 action we were using from the marketplace required us to use the `pull_request_target` event, which runs in the context of the target repository to protect secrets. However, this also meant that flake8 would run on files already merged into our master branch, not the actual changes made in teh PR! That's obviously pretty useless as a guard against merging linting errors into our repository.

This change sidesteps the issue by removing the marketplace action and replacing it by a direct `flake8` run command. To make sure error output ends up as a GitHub Actions Annotation, we ask `flake8` to format its error messages using the correct GitHub Workflow Command format:

```
::error file={filename},line={line},col={col}::{message}
```

Whenever something is printed to stdout/stderr in that format, GitHub Actions will automatically interpret it as the ["register error message" workflow command](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-error-message). Since this doesn't require a GitHub Token with "write" permissions, we
can now switch back to the safer `pull_request` event that only gets a read-only GitHub Token.

This change will result in these neat annotations when a PR contains linting errors:

![2020-11-16_17-01](https://user-images.githubusercontent.com/33516116/99276879-6d75ad00-282d-11eb-9fa8-1eab9702e26f.png)

**Note:** I had to fix some linting errors that were introduced when we ripped out the persistence feature. See the second commit.

#### 2. The `lint` and `build` jobs now have their own workflow file.

I've separated the lint and build jobs into two separate workflows:

- Lint:  .github/workflows/lint.yaml
- Build: .github/workflows/build.yaml

The main difference is that the Build workflow will be triggered if the Lint workflow completes, but only if the current branch is "master" (i.e., it will not run for pull requests). The build job will check if the Lint run was successful and if it were, it actually builds the container, pushes it the GitHub Container Repository, and triggers the deployment to our kubernetes cluster.